### PR TITLE
Basic Mac OSX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+  - osx
 language: php
 php:
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,32 @@
-os:
-  - linux
-  - osx
 language: php
 php:
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+matrix:
+  include:
+    # `php: ..` in here is just descriptive/for UI, they don't affect installed ver.
+    - os: osx
+      php: "5.6"
+      language: generic
+      before_install:
+        - brew update && brew tap homebrew/php && brew install php56
+    - os: osx
+      php: "7.0"
+      language: generic
+      before_install:
+        - brew update && brew tap homebrew/php && brew install php70
+    - os: osx
+      php: "7.1"
+      language: generic
+      before_install:
+        - brew update && brew tap homebrew/php && brew install php71
+    - os: osx
+      php: "7.2"
+      language: generic
+      before_install:
+        - brew update && brew tap homebrew/php && brew install php72
 install:
   - phpize
   - ./configure

--- a/config.m4
+++ b/config.m4
@@ -53,6 +53,7 @@ if test "$PHP_SPX" = "yes"; then
         src/spx_php.c            \
         src/spx_stdio.c          \
         src/spx_config.c         \
-        src/spx_fmt.c,
+        src/spx_fmt.c            \
+        src/spx_utils.c,
         $ext_shared)
 fi

--- a/src/php_spx.h
+++ b/src/php_spx.h
@@ -5,9 +5,9 @@
 #include "main/php.h"
 #include "Zend/zend_extensions.h"
 
-/* linux 2.6+ */
-#ifndef linux
-#   error "Only Linux based OS are supported"
+/* linux 2.6+ or OSX */
+#if !defined(linux) && !(defined(__APPLE__) && defined(__MACH__))
+#   error "Only Linux-based OS or Apple MacOS are supported"
 #endif
 
 #ifndef __x86_64__

--- a/src/spx_profiler.c
+++ b/src/spx_profiler.c
@@ -56,7 +56,7 @@ typedef struct {
 typedef struct {
     size_t depth;
     stack_frame_t frames[STACK_CAPACITY];
-} stack_t;
+} spx_stack_t;
 
 struct spx_profiler_t {
     int finalized;
@@ -75,7 +75,7 @@ struct spx_profiler_t {
     spx_profiler_metric_values_t cum_metric_values;
     spx_profiler_metric_values_t max_metric_values;
 
-    stack_t stack;
+    spx_stack_t stack;
     func_table_t func_table;
 };
 

--- a/src/spx_reporter_fp.c
+++ b/src/spx_reporter_fp.c
@@ -4,6 +4,7 @@
 
 #include "spx_reporter_fp.h"
 #include "spx_thread.h"
+#include "spx_utils.h"
 
 typedef struct {
     spx_profiler_reporter_t base;

--- a/src/spx_resource_stats-macos.c
+++ b/src/spx_resource_stats-macos.c
@@ -35,10 +35,8 @@ size_t spx_resource_stats_cpu_time(void)
 
 void spx_resource_stats_io(size_t * in, size_t * out)
 {
+    // MacOS doesn't expose any per-process I/O counters equivalent to linux
+    // procfs.
     *in = 0;
     *out = 0;
-    struct rusage ru;
-    getrusage(RUSAGE_SELF, &ru);
-    *in  = ru.ru_inblock * 512;
-    *out = ru.ru_oublock * 512;
 }

--- a/src/spx_resource_stats-macos.c
+++ b/src/spx_resource_stats-macos.c
@@ -1,0 +1,44 @@
+#define _GNU_SOURCE
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include "spx_resource_stats.h"
+#include "spx_thread.h"
+
+void spx_resource_stats_init(void)
+{
+}
+
+void spx_resource_stats_shutdown(void)
+{
+}
+
+
+size_t spx_resource_stats_wall_time(void)
+{
+    struct timeval tv;
+    int ret = 0;
+    ret = gettimeofday(&tv, NULL);
+    if (ret == 0) {
+        return tv.tv_sec * 1000 * 1000 + tv.tv_usec;
+    }
+    return ret;
+}
+
+size_t spx_resource_stats_cpu_time(void)
+{
+    struct rusage ru;
+    getrusage(RUSAGE_SELF, &ru);
+    return (ru.ru_utime.tv_sec  + ru.ru_stime.tv_sec ) * 1000 * 1000 +
+           (ru.ru_utime.tv_usec + ru.ru_stime.tv_usec);
+}
+
+void spx_resource_stats_io(size_t * in, size_t * out)
+{
+    *in = 0;
+    *out = 0;
+    struct rusage ru;
+    getrusage(RUSAGE_SELF, &ru);
+    *in  = ru.ru_inblock * 512;
+    *out = ru.ru_oublock * 512;
+}

--- a/src/spx_resource_stats.c
+++ b/src/spx_resource_stats.c
@@ -1,5 +1,7 @@
 #ifdef linux
 #   include "spx_resource_stats-linux.c"
+#elif defined(__APPLE__) && defined(__MACH__)
+#   include "spx_resource_stats-macos.c"
 #else
 #   error "Your platform is not supported. Please open an issue."
 #endif

--- a/src/spx_stdio.c
+++ b/src/spx_stdio.c
@@ -1,4 +1,4 @@
-#ifndef __unix__
+#if !defined(__unix__) && !(defined(__APPLE__) && defined(__MACH__))
 #   error "Your platform is not supported"
 #endif
 

--- a/src/spx_utils.c
+++ b/src/spx_utils.c
@@ -1,0 +1,16 @@
+#include <time.h>
+#include <sys/time.h>
+
+#if defined(__APPLE__) && defined(__MACH__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
+int clock_gettime(int clk_id, struct timespec *res)
+{
+  struct timeval tv;
+  int ret = 0;
+  ret = gettimeofday(&tv, NULL);
+  if (ret == 0) {
+    res->tv_sec = tv.tv_sec;
+    res->tv_nsec = tv.tv_usec * 1000;
+  }
+  return ret;
+}
+#endif

--- a/src/spx_utils.h
+++ b/src/spx_utils.h
@@ -1,6 +1,8 @@
 #ifndef SPX_UTILS_H_DEFINED
 #define SPX_UTILS_H_DEFINED
 
+#include <time.h>
+
 #define SPX_UTILS_TOKENIZE_STRING(str, delim, token, size, block) \
 do {                                                              \
     const char * c_ = str;                                        \
@@ -26,5 +28,13 @@ do {                                                              \
         c_++;                                                     \
     }                                                             \
 } while (0)
+
+
+#if defined(__APPLE__) && defined(__MACH__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
+#define CLOCK_REALTIME 1
+#define CLOCK_REALTIME_COARSE 2
+typedef int clockid_t;
+int clock_gettime(clockid_t clk_id, struct timespec *res);
+#endif
 
 #endif /* SPX_UTILS_H_DEFINED */


### PR DESCRIPTION
I saw that issue #7 was marked as postponed, but since I wanted this for my own purposes I decided to have a go.

This implements the minimum possible changes to build & run on OSX/macos. Some notable points:

- Fine-grained timing isn't available as cheaply/simply as on linux, so I've used coarser clocks/timing info. I doubt this is too much of an issue, as everything in the linux impl is converted down to µsec anyway.
- No I/O stats. I've searched high and low and can't find any I/O stats per-process in osx without using dtrace, which feels excessive: it would be a complicated integration, requires root, and requires a [one-off SIP reconfiguration](https://8thlight.com/blog/colin-jones/2017/02/02/dtrace-gotchas-on-osx.html).

This was built & tested on 10.11 (El Capitan), which is the same as the travis tests. The `clock_gettime` shim is apparently not required in 10.12+  but I haven't tested it yet.