### PR TITLE
Nanosecond timers for macos, where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,22 @@ matrix:
       php: "5.6"
       language: generic
       before_install:
-        - brew update && brew tap homebrew/php && brew install php56
+        - brew update && brew install php@5.6 && brew link --force --overwrite php@5.6
     - os: osx
       php: "7.0"
       language: generic
       before_install:
-        - brew update && brew tap homebrew/php && brew install php70
+        - brew update && brew install php@7.0 && brew link --force --overwrite php@7.0
     - os: osx
       php: "7.1"
       language: generic
       before_install:
-        - brew update && brew tap homebrew/php && brew install php71
+        - brew update && brew install php@7.1 && brew link --force --overwrite php@7.1
     - os: osx
       php: "7.2"
       language: generic
       before_install:
-        - brew update && brew tap homebrew/php && brew install php72
+        - brew update && brew install php@7.2 && brew link --force --overwrite php@7.2
 install:
   - phpize
   - ./configure

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Being a tracing profiler, SPX is subject to accuracy issues for time related met
 - close or lower than the timer precision
 - close or lower than SPX's own per function overhead
 
-The first issue is mitigated by using the highest resolution timer provided by the platform. For example the Linux timer resolution is 1ns while the macOS timer resolution is only 1us.
+The first issue is mitigated by using the highest resolution timer provided by the platform. On Linux & recent macOS versions the timer resolution is 1ns; on macOS before 10.12/Sierra, the timer resolution is only 1us.
 
 The second issue is mitigated by taking in account SPX time (wall / cpu) overhead by subtracting it to measured function execution time. This is done by evaluating SPX constant per function overhead before starting profiling the script.
 

--- a/src/spx_resource_stats-macos.c
+++ b/src/spx_resource_stats-macos.c
@@ -14,21 +14,6 @@ void spx_resource_stats_shutdown(void)
 
 #define TIMESPEC_TO_NS(ts) ((ts).tv_sec * 1000 * 1000 * 1000 + (ts).tv_nsec)
 
-// Coarser (usec) wall time for macOS < Sierra
-size_t spx_resource_stats_wall_time_coarse(void)
-{
-    struct timeval tv;
-    int ret = 0;
-    ret = gettimeofday(&tv, NULL);
-    if (ret == 0) {
-        return 1000 * (
-            tv.tv_sec * 1000 * 1000
-                + tv.tv_usec
-        );
-    }
-    return ret;
-}
-
 size_t spx_resource_stats_wall_time(void)
 {
 #if (__MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
@@ -38,18 +23,6 @@ size_t spx_resource_stats_wall_time(void)
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return TIMESPEC_TO_NS(ts);
 #endif
-}
-
-// Coarser (usec) cpu use time for macOS < Sierra
-size_t spx_resource_stats_cpu_time_coarse(void)
-{
-    struct rusage ru;
-    getrusage(RUSAGE_SELF, &ru);
-
-    return 1000 * (
-        (ru.ru_utime.tv_sec  + ru.ru_stime.tv_sec ) * 1000 * 1000
-            + (ru.ru_utime.tv_usec + ru.ru_stime.tv_usec)
-    );
 }
 
 size_t spx_resource_stats_cpu_time(void)
@@ -69,4 +42,31 @@ void spx_resource_stats_io(size_t * in, size_t * out)
     // procfs.
     *in = 0;
     *out = 0;
+}
+
+// Coarser (usec) wall time for macOS < Sierra
+static inline size_t spx_resource_stats_wall_time_coarse(void)
+{
+    struct timeval tv;
+    int ret = 0;
+    ret = gettimeofday(&tv, NULL);
+    if (ret == 0) {
+        return 1000 * (
+            tv.tv_sec * 1000 * 1000
+                + tv.tv_usec
+        );
+    }
+    return ret;
+}
+
+// Coarser (usec) cpu use time for macOS < Sierra
+static inline size_t spx_resource_stats_cpu_time_coarse(void)
+{
+    struct rusage ru;
+    getrusage(RUSAGE_SELF, &ru);
+
+    return 1000 * (
+        (ru.ru_utime.tv_sec  + ru.ru_stime.tv_sec ) * 1000 * 1000
+            + (ru.ru_utime.tv_usec + ru.ru_stime.tv_usec)
+    );
 }


### PR DESCRIPTION
As discussed in #30, uses `clock_gettime` for nanosecond resolution timing on macos >= 10.12 (Sierra), keeping the coarser microsecond timings on older versions.