### PR TITLE
Fix segfaults/infinite loops when using PHP built-in CLI server.

### DIFF
--- a/src/spx_php.c
+++ b/src/spx_php.c
@@ -364,7 +364,7 @@ void spx_php_hooks_init(void)
     ze_hook.zend_write = zend_write;
     zend_write = hook_zend_write;
 
-    if (sapi_module.send_headers) {
+    if (sapi_module.send_headers && sapi_module.send_headers != hook_send_headers) {
         ze_hook.send_headers = sapi_module.send_headers;
         sapi_module.send_headers = hook_send_headers;
     }
@@ -403,7 +403,6 @@ void spx_php_hooks_shutdown(void)
 
     if (ze_hook.send_headers) {
         sapi_module.send_headers = ze_hook.send_headers;
-        ze_hook.send_headers = NULL;
     }
 
     if (ze_hook.send_header) {


### PR DESCRIPTION
I've seen repeated issues with segfaults & indefinite hangs when using the PHP built-in CLI server with SPX enabled. I've finally pinned it down – it happens after a static file has been served by the built-in server (it was affecting me so badly because Chrome was aggressively re-requesting favicon.ico all the time).

The root cause is that, when serving static files, the php cli server does the following:

- temporarily replaces `sapi_module.send_headers` with a no-op func
- ends the request (causing spx shutdown to occur)
- puts `sapi_module.send_headers` back to what it was.

See [php_cli_server.c](https://github.com/php/php-src/blob/5e106778f01ba09b3a0367af9713c9131be4e430/sapi/cli/php_cli_server.c#L2179-L2181).

This conflicts with the way spx "hooks" `sapi_module.send_headers`: It is hooked early in execution, then it's _meant_ to be cleaned up during shutdown. When SPX is enabled & a static file is requested, `php_cli_server` partially _un-does_ the spx cleanup: for the next request, `sapi_module.send_headers` has been set back to SPX's hooked version!

I can't quite see all the various cases that this causes (I think it's kind of a race condition, since spx can shutdown in other ways at other times too, and also consider multiple static files being requested) – but I've definitely observed the two following cases: immediate segfaults (from `ze_hook.send_headers` being null), and indefinite hangs/eventual segfaults (`hook_send_header` calling itself endlessly until overflow).

This PR is a minimal change to avoid these problems, by A) keeping a reference to the original `send_headers` all the time, and B) only hooking when the function pointers in question are different.

I'm not sure if this is the right way to fix this, but it seemed the least invasive. I think it'll be safe for other SAPIs, but I haven't tested that yet. I also haven't addressed any other hooking; I only saw issues with `send_headers`.