### PR TITLE
User-definable Categories in web UI

### DIFF
--- a/assets/web-ui/css/main.css
+++ b/assets/web-ui/css/main.css
@@ -1,12 +1,4 @@
 body {
-    background: #023;
-    background: -webkit-linear-gradient(#023, #000);
-    background: -o-linear-gradient(#023, #000);
-    background: -moz-linear-gradient(#023, #000);
-    background: linear-gradient(#023, #000);
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-
     font-family: monospace;
     margin: 2px;
     padding: 0;
@@ -14,6 +6,16 @@ body {
 
 * {
     color: #089;
+}
+
+body, #colorscheme-panel {
+    background: #023;
+    background: -webkit-linear-gradient(#023, #000);
+    background: -o-linear-gradient(#023, #000);
+    background: -moz-linear-gradient(#023, #000);
+    background: linear-gradient(#023, #000);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
 }
 
 form#config label {
@@ -150,6 +152,14 @@ table.layout td {
 
 #metric-selector select {
     background-color: #000;
+}
+
+#colorscheme-panel {
+    display: none;
+    position: absolute;
+    top: 24px;
+    width: 300px;
+    padding: 6px;
 }
 
 #category-legend {

--- a/assets/web-ui/css/main.css
+++ b/assets/web-ui/css/main.css
@@ -152,6 +152,10 @@ table.layout td {
     background-color: #000;
 }
 
+#category-legend {
+    display: none;
+}
+
 #flatprofile {
     h: right;
 }

--- a/assets/web-ui/css/main.css
+++ b/assets/web-ui/css/main.css
@@ -158,16 +158,48 @@ table.layout td {
     display: none;
     position: absolute;
     top: 24px;
-    width: 300px;
+    width: 350px;
     padding: 6px;
+}
+
+#colorscheme-panel ol {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+#colorscheme-panel hr {
+    border-color: #089;
+}
+
+#colorscheme-panel button, #colorscheme-panel input, #colorscheme-panel textarea {
+    font-family: monospace;
+    font-size: 12px;
+    background-color: #000;
+    border: 1px solid #0898;
+}
+
+#colorscheme-panel .category {
+    margin: 10px 0 0;
+}
+
+#colorscheme-panel input[name="label"] {
+    width: 181px;
+}
+
+#colorscheme-panel textarea[name="patterns"] {
+    width: calc(100% - 6px);
+}
+
+#colorscheme-panel .swatch {
+    display: inline-block;
+    width: 15px;
+    height: 15px;
+    border: 1px solid #eee;
 }
 
 #category-legend {
     display: none;
-}
-
-#flatprofile {
-    h: right;
 }
 
 #flatprofile table {

--- a/assets/web-ui/css/main.css
+++ b/assets/web-ui/css/main.css
@@ -191,11 +191,9 @@ table.layout td {
     width: calc(100% - 6px);
 }
 
-#colorscheme-panel .swatch {
-    display: inline-block;
-    width: 15px;
+#colorscheme-panel .jscolor {
+    width: 45px;
     height: 15px;
-    border: 1px solid #eee;
 }
 
 #category-legend {

--- a/assets/web-ui/js/utils.js
+++ b/assets/web-ui/js/utils.js
@@ -237,6 +237,18 @@ export function setCategories(categories) {
     window.localStorage.setItem(categStoreKey, JSON.stringify(categories));
 }
 
+export function getCallCategoryColor(funcName) {
+    let categories = getCategories();
+    for (let category of categories) {
+        for (let pattern of category.patterns) {
+            if (pattern.test(funcName)) {
+                pattern.lastIndex = 0;
+                return `rgb(${category.color[0]},${category.color[1]},${category.color[2]})`;
+            }
+        }
+    }
+}
+
 export function getCallMetricValueColor(profileData, metric, value) {
     const metricRange = profileData.getStats().getCallRange(metric);
 

--- a/assets/web-ui/js/utils.js
+++ b/assets/web-ui/js/utils.js
@@ -205,6 +205,38 @@ export class PackedRecordArray {
     }
 }
 
+let categCache = null;
+const categStoreKey = 'spx-report-current-categories';
+
+export function getCategories() {
+    if (!!categCache) { return categCache; }
+
+    let loaded = window.localStorage.getItem(categStoreKey);
+    categCache = !!loaded ? JSON.parse(loaded): [];
+    categCache.forEach(c => {
+        c.patterns = c.patterns.map(p => new RegExp(p, 'gi'))
+    });
+
+    categCache.push({
+        label: '<uncategorized>',
+        color: [140,140,140],
+        patterns: [/./],
+        isDefault: true
+    })
+
+    return categCache;
+}
+
+export function setCategories(categories) {
+    categCache = null;
+    categories = categories
+        .filter(c => !c.isDefault)
+        .forEach(c => {
+            c.patterns = c.patterns.split(/[\r\n]+/);
+        });
+    window.localStorage.setItem(categStoreKey, JSON.stringify(categories));
+}
+
 export function getCallMetricValueColor(profileData, metric, value) {
     const metricRange = profileData.getStats().getCallRange(metric);
 

--- a/assets/web-ui/js/utils.js
+++ b/assets/web-ui/js/utils.js
@@ -204,3 +204,29 @@ export class PackedRecordArray {
         return field.typeArray[idx * field.typeElemSize + field.typeOffset];
     }
 }
+
+export function getCallMetricValueColor(profileData, metric, value) {
+    const metricRange = profileData.getStats().getCallRange(metric);
+
+    let scaleValue = 0;
+
+    if (metricRange.length() > 100) {
+        scaleValue =
+            Math.log10(value - metricRange.begin)
+                / Math.log10(metricRange.length())
+        ;
+    } else {
+        scaleValue = metricRange.lerp(value);
+    }
+
+    return math.Vec3.lerpPath(
+        [
+            new math.Vec3(0, 0.3, 0.9),
+            new math.Vec3(0, 0.9, 0.9),
+            new math.Vec3(0, 0.9, 0),
+            new math.Vec3(0.9, 0.9, 0),
+            new math.Vec3(0.9, 0.2, 0),
+        ],
+        scaleValue
+    ).toHTMLColor();
+}

--- a/assets/web-ui/js/widget.js
+++ b/assets/web-ui/js/widget.js
@@ -380,6 +380,62 @@ class SVGWidget extends Widget {
     }
 }
 
+export class ColorSchemeControls extends Widget {
+
+    constructor(container, profileData) {
+        super(container, profileData);
+
+        this.panelOpen = false;
+
+        this.toggleLink = container.find('#colorscheme-current-name');
+        this.panel = container.find('#colorscheme-panel');
+
+        this.toggleLink.on('click', e => {
+            e.preventDefault();
+            this.togglePanel();
+        });
+
+        container.find('input[name="colorscheme-mode"]:radio').on('change', e => {
+            if (!e.target.checked) { return };
+
+            $(window).trigger('spx-colorscheme-update', [e.target.value]);
+            let label = this.panel.find(`label[for="${e.target.id}"]`);
+            this.toggleLink.html(label.html());
+        });
+    }
+
+    clear() { }
+
+    togglePanel() {
+        this.panelOpen = !this.panelOpen;
+        this.panel.toggle();
+        if (this.panelOpen) {
+            this.repaint();
+            setTimeout(() => this.listenForPanelClose(), 0);
+        }
+    }
+
+    listenForPanelClose() {
+        let onOutsideClick = e => {
+            if (e.target.closest('#colorscheme-panel') !== null) { return; }
+            e.preventDefault();
+            off()
+            this.togglePanel();
+        }
+        let onEscKey = e => {
+            if (e.key != 'Escape') { return; }
+            off();
+            this.togglePanel();
+        }
+        let off = () => {
+            $(document).off('mousedown', onOutsideClick);
+            $(document).off('keydown', onEscKey);
+        }
+        $(document).on('mousedown', onOutsideClick);
+        $(document).on('keydown', onEscKey);
+    }
+}
+
 export class ColorScale extends SVGWidget {
 
     constructor(container, profileData) {

--- a/assets/web-ui/js/widget.js
+++ b/assets/web-ui/js/widget.js
@@ -176,33 +176,6 @@ function renderSVGMetricValuesPlot(viewPort, profileData, metric, timeRange) {
     }
 }
 
-function getCallMetricValueColor(profileData, metric, value) {
-    const metricRange = profileData.getStats().getCallRange(metric);
-
-    let scaleValue = 0;
-
-    if (metricRange.length() > 100) {
-        scaleValue =
-            Math.log10(value - metricRange.begin)
-                / Math.log10(metricRange.length())
-        ;
-    } else {
-        scaleValue = metricRange.lerp(value);
-    }
-
-    return math.Vec3.lerpPath(
-        [
-            new math.Vec3(0, 0.3, 0.9),
-            new math.Vec3(0, 0.9, 0.9),
-            new math.Vec3(0, 0.9, 0),
-            new math.Vec3(0.9, 0.9, 0),
-            new math.Vec3(0.9, 0.2, 0),
-        ],
-        scaleValue
-    ).toHTMLColor();
-}
-
-
 class ViewTimeRange {
 
     constructor(timeRange, wallTime, viewWidth) {
@@ -434,7 +407,7 @@ export class ColorScale extends SVGWidget {
                 y: 0,
                 width: step,
                 height: this.viewPort.height,
-                fill: getCallMetricValueColor(
+                fill: utils.getCallMetricValueColor(
                     this.profileData,
                     this.currentMetric,
                     getCurrentMetricValue(i)
@@ -461,9 +434,10 @@ export class ColorScale extends SVGWidget {
 
 export class OverView extends SVGWidget {
 
-    constructor(container, profileData) {
+    constructor(container, profileData, colorChooser) {
         super(container, profileData);
-        
+
+        this.colorChooser = colorChooser;
         this.viewTimeRange = new ViewTimeRange(
             this.profileData.getTimeRange(),
             this.profileData.getWallTime(),
@@ -567,10 +541,10 @@ export class OverView extends SVGWidget {
                 y1: y,
                 x2: x + w,
                 y2: y + h,
-                stroke: getCallMetricValueColor(
+                stroke: this.colorChooser(
                     this.profileData,
                     this.currentMetric,
-                    call.getInc(this.currentMetric)
+                    call
                 ),
             }));
         }
@@ -608,9 +582,10 @@ export class OverView extends SVGWidget {
 
 export class TimeLine extends SVGWidget {
 
-    constructor(container, profileData) {
+    constructor(container, profileData, colorChooser) {
         super(container, profileData);
 
+        this.colorChooser = colorChooser;
         this.viewTimeRange = new ViewTimeRange(
             this.profileData.getTimeRange(),
             this.profileData.getWallTime(),
@@ -806,10 +781,10 @@ export class TimeLine extends SVGWidget {
                 height: h,
                 stroke: 'none',
                 'stroke-width': 2,
-                fill: getCallMetricValueColor(
+                fill: this.colorChooser(
                     this.profileData,
                     this.currentMetric,
-                    call.getInc(this.currentMetric)
+                    call
                 ),
                 'data-call-idx': call.getIdx(),
             });

--- a/assets/web-ui/js/widget.js
+++ b/assets/web-ui/js/widget.js
@@ -432,6 +432,39 @@ export class ColorScale extends SVGWidget {
     }
 }
 
+export class CategoryLegend extends SVGWidget {
+
+    constructor(container, profileData) {
+        super(container, profileData);
+    }
+
+    render() {
+        let categories = utils.getCategories()
+        let width = this.viewPort.width / categories.length;
+
+        for (let i = 0; i < categories.length; i++) {
+            let category = categories[i];
+            let [r, g, b] = category.color;
+            this.viewPort.appendChild(svg.createNode('rect', {
+                x: width * i,
+                y: 0,
+                width,
+                height: this.viewPort.height,
+                fill: `rgb(${r},${g},${b})`,
+            }));
+            this.viewPort.appendChild(svg.createNode('text', {
+                x: width * i + 4,
+                y: 13,
+                width,
+                height: this.viewPort.height,
+                fill: `rgb(${r},${g},${b})`,
+                'font-size': 12,
+                fill: '#000',
+            }, node => { node.textContent = category.label }));
+        }
+    }
+}
+
 export class OverView extends SVGWidget {
 
     constructor(container, profileData, colorChooser) {

--- a/assets/web-ui/report.html
+++ b/assets/web-ui/report.html
@@ -30,6 +30,9 @@
                     <label for="colorscheme-mode-scale">Selected metric</label>
                     <input type="radio" name="colorscheme-mode" id="colorscheme-mode-categories" value="categories" />
                     <label for="colorscheme-mode-categories">Categories</label>
+                    <hr />
+                    <button id="new-category">Add new category</button>
+                    <ol></ol>
                 </div>
             </div>
         </td><td>

--- a/assets/web-ui/report.html
+++ b/assets/web-ui/report.html
@@ -22,6 +22,16 @@
                 <select>
                 </select>
             </div>
+        </td><td style="width: 15%; min-width: 100px;">
+            <div id="colorscheme-selector" class="widget" style="width: 100%; height: 24px">
+                <span>Color by: </span><a href="#" id="colorscheme-current-name">Selected metric</a>
+                <div id="colorscheme-panel">
+                    <input type="radio" name="colorscheme-mode" id="colorscheme-mode-scale" value="scale" checked />
+                    <label for="colorscheme-mode-scale">Selected metric</label>
+                    <input type="radio" name="colorscheme-mode" id="colorscheme-mode-categories" value="categories" />
+                    <label for="colorscheme-mode-categories">Categories</label>
+                </div>
+            </div>
         </td><td>
             <div style="width:100%; position: relative">
                 <div id="color-scale" class="widget" style="width: 100%; height: 24px"></div>
@@ -215,17 +225,22 @@
                     const widgets = [
                         new widget.ColorScale($('#color-scale'), profileData),
                         new widget.CategoryLegend($('#category-legend'), profileData),
+                        new widget.ColorSchemeControls($('#colorscheme-selector'), profileData),
                         new widget.OverView($('#overview'), profileData, colorChooser),
                         new widget.TimeLine($('#timeline'), profileData, colorChooser),
                         new widget.FlatProfile($('#flatprofile'), profileData),
                         new widget.FlameGraph($('#flamegraph'), profileData),
                     ];
 
+                    const colSchemeWidgets = [widgets[0], widgets[1]];
+
                     $(window).on('spx-colorscheme-update', (e, newMode=null) => {
                         if (!!newMode && colorMode !== newMode) {
                             colorMode = newMode;
-                            $('#color-scale').toggle();
-                            $('#category-legend').toggle();
+                            colSchemeWidgets.forEach(widget => {
+                                widget.container.toggle();
+                                widget._fitToContainerSize();
+                            });
                         }
                         widgets.forEach(widget => widget.repaint());
                     });

--- a/assets/web-ui/report.html
+++ b/assets/web-ui/report.html
@@ -23,7 +23,10 @@
                 </select>
             </div>
         </td><td>
-            <div id="color-scale" class="widget" style="width: 100%; height: 24px"></div>
+            <div style="width:100%; position: relative">
+                <div id="color-scale" class="widget" style="width: 100%; height: 24px"></div>
+                <div id="category-legend" class="widget" style="width: 100%; height: 24px"></div>
+            </div>
         </td>
     </tr></table>
 
@@ -194,19 +197,38 @@
                     return new Promise(resolve => resolve(profileDataBuilder.getProfileData()));
                 })
                 .then(profileData => {
+
+                    const COLOUR_SCALE = 'scale';
+                    const COLOUR_CATEGORIES = 'categories';
+
+                    let colorMode = COLOUR_SCALE;
                     let colorChooser = function(profileData, metric, call) {
-                        return utils.getCallMetricValueColor(profileData, metric, call.getInc(metric));
+                        if (colorMode == COLOUR_SCALE) {
+                            return utils.getCallMetricValueColor(profileData, metric, call.getInc(metric));
+                        } else if (colorMode == COLOUR_CATEGORIES) {
+                            return utils.getCallCategoryColor(call.getFunctionName());
+                        } else {
+                            throw new Error(`Unknown color mode ${colorMode}`);
+                        }
                     };
 
                     const widgets = [
                         new widget.ColorScale($('#color-scale'), profileData),
+                        new widget.CategoryLegend($('#category-legend'), profileData),
                         new widget.OverView($('#overview'), profileData, colorChooser),
                         new widget.TimeLine($('#timeline'), profileData, colorChooser),
                         new widget.FlatProfile($('#flatprofile'), profileData),
                         new widget.FlameGraph($('#flamegraph'), profileData),
                     ];
 
-                    widgets.forEach(widget => widget.render());
+                    $(window).on('spx-colorscheme-update', (e, newMode=null) => {
+                        if (!!newMode && colorMode !== newMode) {
+                            colorMode = newMode;
+                            $('#color-scale').toggle();
+                            $('#category-legend').toggle();
+                        }
+                        widgets.forEach(widget => widget.repaint());
+                    });
 
                     const metricSelector = $('#metric-selector select');
                     for (const metric of profileData.getMetadata().enabled_metrics) {

--- a/assets/web-ui/report.html
+++ b/assets/web-ui/report.html
@@ -60,6 +60,12 @@
         crossorigin="anonymous"
     ></script>
 
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
+        integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro="
+        crossorigin="anonymous"
+    ></script>
+
     <!-- Required workaround for Firefox to fix a "no credentials" issue -->
     <script type="module" crossorigin src="./js/utils.js"></script>
     <script type="module" crossorigin src="./js/fmt.js"></script>

--- a/assets/web-ui/report.html
+++ b/assets/web-ui/report.html
@@ -52,7 +52,7 @@
 
     <script type="module" crossorigin>
         import * as fmt from './js/fmt.js';
-        import {processCallChain} from './js/utils.js';
+        import * as utils from './js/utils.js';
         import {ProfileDataBuilder} from './js/profileData.js';
         import * as widget from './js/widget.js';
 
@@ -194,10 +194,14 @@
                     return new Promise(resolve => resolve(profileDataBuilder.getProfileData()));
                 })
                 .then(profileData => {
+                    let colorChooser = function(profileData, metric, call) {
+                        return utils.getCallMetricValueColor(profileData, metric, call.getInc(metric));
+                    };
+
                     const widgets = [
                         new widget.ColorScale($('#color-scale'), profileData),
-                        new widget.OverView($('#overview'), profileData),
-                        new widget.TimeLine($('#timeline'), profileData),
+                        new widget.OverView($('#overview'), profileData, colorChooser),
+                        new widget.TimeLine($('#timeline'), profileData, colorChooser),
                         new widget.FlatProfile($('#flatprofile'), profileData),
                         new widget.FlameGraph($('#flamegraph'), profileData),
                     ];


### PR DESCRIPTION
As discussed in #43, an initial implementation of user-definable categories in the web UI.

It won't win any awards for UX or front-end code quality, but it's reasonably functional! I tried to keep code changes to a minimum but of course there is some fiddly UI state management required.

This change only adds support for colouring categories in the overview/timeline widgets – I haven't done the flat profile table yet.

You can add & remove categories; edit their labels, regex patterns & colours; and change the precedence order. Click outside of the panel (or press esc) to dismiss.

Here's a [gif](https://d3vv6lp55qjaqc.cloudfront.net/items/1M1b1q3k2i2C0C0X3U2P/Screen%20Recording%202018-04-06%20at%2002.14%20pm.gif) showing it in action.