### PR TITLE
Fix ownership issue & fix #42

### DIFF
--- a/src/spx_profiler.c
+++ b/src/spx_profiler.c
@@ -190,8 +190,6 @@ spx_profiler_t * spx_profiler_create(
 error:
     if (profiler) {
         spx_profiler_destroy(profiler);
-    } else {
-        spx_profiler_reporter_destroy(reporter);
     }
 
     return NULL;
@@ -199,8 +197,6 @@ error:
 
 void spx_profiler_destroy(spx_profiler_t * profiler)
 {
-    spx_profiler_reporter_destroy(profiler->reporter);
-
     if (profiler->metric_collector) {
         spx_metric_collector_destroy(profiler->metric_collector);
     }

--- a/src/spx_reporter_full.h
+++ b/src/spx_reporter_full.h
@@ -1,8 +1,6 @@
 #ifndef SPX_REPORTER_FULL_H_DEFINED
 #define SPX_REPORTER_FULL_H_DEFINED
 
-#include <unistd.h>
-
 #include "spx_profiler.h"
 
 size_t spx_reporter_full_metadata_list_files(


### PR DESCRIPTION
- Profiler object does not have anymore the responsability to destroy its passed (at creation time) reporter
- Signal handler does not call `exit()` anymore (fix #42)