### PR TITLE
CLI: Add color scheme to flat profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ Here is the list below:
 | _SPX_FP_INC_ | `0` | Whether to sort functions by inclusive value instead of exclusive value in flat profile. |
 | _SPX_FP_REL_ | `0` | Whether to display metric values as relative (i.e. percentage) in flat profile. |
 | _SPX_FP_LIMIT_ | `10` | The flat profile size (i.e. top N shown functions). |
-| _SPX_FP_LIVE_ | `0` | Whether to enabled flat profile live refresh. Since it uses ANSI escape sequences, it uses STDOUT as output, replacing script output (both STDOUT & STDERR). |
+| _SPX_FP_LIVE_ | `0` | Whether to enable flat profile live refresh. Since it plays with cursor position through ANSI escape sequences, it uses STDOUT as output, replacing script output (both STDOUT & STDERR). |
+| _SPX_FP_COLOR_ | `1` | Whether to enable flat profile color mode. |
 | _SPX_TRACE_SAFE_ | `0` | The trace file is by default written in a way to enforce accuracy, but in case of process crash (e.g. segfault) some logs could be lost. If you want to enforce durability (e.g. to find the last event before a crash) you just have to set this parameter to 1. |
 | _SPX_TRACE_FILE_ |  | Custom trace file name. If not specified it will be generated in `/tmp` and displayed on STDERR at the end of the script. |
 

--- a/src/php_spx.c
+++ b/src/php_spx.c
@@ -374,7 +374,8 @@ static void profiling_handler_init(void)
                 context.config.fp_inc,
                 context.config.fp_rel,
                 context.config.fp_limit,
-                context.config.fp_live
+                context.config.fp_live,
+                context.config.fp_color
             );
 
             break;

--- a/src/spx_config.c
+++ b/src/spx_config.c
@@ -24,6 +24,7 @@ typedef struct {
     const char * fp_rel_str;
     const char * fp_limit_str;
     const char * fp_live_str;
+    const char * fp_color_str;
 
     const char * trace_file;
     const char * trace_safe_str;
@@ -111,6 +112,7 @@ static void init_config(spx_config_t * config, int cli)
     config->fp_rel = 0;
     config->fp_limit = 10;
     config->fp_live = 0;
+    config->fp_color = 1;
 
     config->trace_file = NULL;
     config->trace_safe = 0;
@@ -151,6 +153,7 @@ static void source_data_get(source_data_t * source_data, source_handler_t handle
     source_data->fp_rel_str           = handler("SPX_FP_REL");
     source_data->fp_limit_str         = handler("SPX_FP_LIMIT");
     source_data->fp_live_str          = handler("SPX_FP_LIVE");
+    source_data->fp_color_str         = handler("SPX_FP_COLOR");
     source_data->trace_file           = handler("SPX_TRACE_FILE");
     source_data->trace_safe_str       = handler("SPX_TRACE_SAFE");
 }
@@ -225,6 +228,10 @@ static void source_data_to_config(const source_data_t * source_data, spx_config_
 
     if (source_data->fp_live_str) {
         config->fp_live = *source_data->fp_live_str == '1' ? 1 : 0;
+    }
+
+    if (source_data->fp_color_str) {
+        config->fp_color = *source_data->fp_color_str == '1' ? 1 : 0;
     }
 
     if (source_data->trace_file) {

--- a/src/spx_config.h
+++ b/src/spx_config.h
@@ -28,6 +28,7 @@ typedef struct {
     int fp_rel;
     size_t fp_limit;
     int fp_live;
+    int fp_color;
 
     const char * trace_file;
     int trace_safe;

--- a/src/spx_fmt.h
+++ b/src/spx_fmt.h
@@ -42,6 +42,14 @@ void spx_fmt_row_add_ncell(
     double value
 );
 
+void spx_fmt_row_add_ncellf(
+    spx_fmt_row_t * row,
+    size_t span,
+    spx_fmt_value_type_t type,
+    double value,
+    const char * ansi_fmt
+);
+
 void spx_fmt_row_print(const spx_fmt_row_t * row, spx_output_stream_t * output);
 void spx_fmt_row_print_sep(const spx_fmt_row_t * row, spx_output_stream_t * output);
 

--- a/src/spx_reporter_fp.h
+++ b/src/spx_reporter_fp.h
@@ -8,7 +8,8 @@ spx_profiler_reporter_t * spx_reporter_fp_create(
     int inc,
     int rel,
     size_t limit,
-    int live
+    int live,
+    int color
 );
 
 #endif /* SPX_REPORTER_FP_H_DEFINED */


### PR DESCRIPTION
Printed values are now colored according to their weights (i.e.
distance from max value) when STDOUT is a TTY.

Resolve #52