### PR TITLE
macOS 10.11-: add forward function declarations

### DIFF
--- a/src/spx_resource_stats-macos.c
+++ b/src/spx_resource_stats-macos.c
@@ -4,6 +4,9 @@
 
 #include "spx_resource_stats.h"
 
+static inline size_t spx_resource_stats_wall_time_coarse(void);
+static inline size_t spx_resource_stats_cpu_time_coarse(void);
+
 void spx_resource_stats_init(void)
 {
 }


### PR DESCRIPTION
On macOS 10.11 and lower, spx_resource_stats_*_coarse() local functions
defined & used in src/spx_resource_stats-macos.c were not properly
declared on top of file, resulting in a compilation error (missing
declaration) on these platforms.

Fixes #78