### PR TITLE
Make a test not affected by libc implementation

### DIFF
--- a/tests/spx_013.phpt
+++ b/tests/spx_013.phpt
@@ -19,7 +19,7 @@ function foo() {
 
 function bar() {
     trigger_error('');
-    for ($i = 0; $i < 15; $i++) {
+    for ($i = 0; $i < 17; $i++) {
         foo();
     }
 }
@@ -27,7 +27,7 @@ function bar() {
 error_reporting(0);
 
 trigger_error('');
-for ($i = 0; $i < 10; $i++) {
+for ($i = 0; $i < 13; $i++) {
     bar();
 }
 
@@ -37,16 +37,16 @@ for ($i = 0; $i < 10; $i++) {
 
 Global stats:
 
-  Called functions    :    38.6K
+  Called functions    :    71.8K
   Distinct functions  :        3
 
-  ZE error count      :    38.6K
+  ZE error count      :    71.8K
 
 Flat profile:
 
  ZE error count      |
  Inc.     | *Exc.    | Called   | Function
 ----------+----------+----------+----------
-    38.5K |    36.1K |    36.1K | 2@foo
-    38.6K |     2.4K |     2.4K | 2@bar
-    38.6K |        1 |        1 | %s/spx_013.php
+    71.8K |    67.8K |    67.8K | 2@foo
+    71.8K |     4.0K |     4.0K | 2@bar
+    71.8K |        1 |        1 | %s/spx_013.php


### PR DESCRIPTION
spx_013.phpt test calls `foo` function 36150 times. This value is
then converted to `36.15` and then formatted by printf with `%7.1f`
as format.
The expected formatted value is `36.1`, which is the output of glibc.
However musl libc output is `36.2`. This is due to the fact that
musl libc *printf implementation takes default FP rounding mode into
account (round half to even) while glibc does not.
This fix is just a workaround to make this test not affected by this
difference between these 2 libc implementations.

Fixes #84