### PR TITLE
Make spx_ui_assets_dir respect INSTALL_ROOT

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,5 +1,5 @@
 
-spx_ui_assets_dir = $(prefix)/share/misc/php-spx/assets/web-ui
+spx_ui_assets_dir = $(INSTALL_ROOT)$(prefix)/share/misc/php-spx/assets/web-ui
 
 CFLAGS += -DSPX_HTTP_UI_ASSETS_DIR=\"$(spx_ui_assets_dir)\"
 


### PR DESCRIPTION
As packaging shows https://travis-ci.org/alpinelinux/aports/builds/449814270

Assets install should allow install into configurable directory (php extensions use `INSTALL_ROOT` for `make install`)

```
Installing SPX web UI to: /usr/share/misc/php-spx/assets/web-ui
mkdir: can't create directory '/usr/share/misc/php-spx/': Permission denied
make: *** [Makefile:199: install-spx-ui-assets] Error 1
make: *** Waiting for unfinished jobs....
Installing shared extensions:     /home/travis/build/alpinelinux/aports/testing/php7-spx/pkg/php7-spx/usr/lib/php7/modules/
```