### PR TITLE
Sampling profiler: improve performance

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_SPX" = "yes"; then
 
     AC_DEFINE(HAVE_SPX, 1, [spx])
 
-    CFLAGS="-Werror -Wall -O3"
+    CFLAGS="-Werror -Wall -O3 -pthread"
     if test "$CONTINUOUS_INTEGRATION" = "true"
     then
         CFLAGS="$CFLAGS -DCONTINUOUS_INTEGRATION"


### PR DESCRIPTION
The current implementation of sampling profiler decorator, based on
XHProf one, has still a lower (compared to tracing profiler) but
significant overhead due to the fact that it calls `clock_gettime()`
on each function call/start.

This patch make it use a background thread.

It may also fix #91 as `last_sample_time_ns` was not properly
initialized in previous implementation.