### PR TITLE
Change repository to https-version in "Install the extension" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Current requirements are:
 ### Install the extension
 
 ```shell
-git clone git@github.com:NoiseByNorthwest/php-spx.git
+git clone https://github.com/NoiseByNorthwest/php-spx.git
 cd php-spx
 phpize
 ./configure


### PR DESCRIPTION
Fatal error occurs without SSH keys in your account:
```
git clone git@github.com:NoiseByNorthwest/php-spx.git
Cloning into 'php-spx'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```