### PR TITLE
Allow to define the profiled spans at runtime

### DIFF
--- a/src/spx_config.c
+++ b/src/spx_config.c
@@ -30,6 +30,8 @@ typedef struct {
 
     const char * ui_uri_str;
 
+    const char * auto_start_str;
+
     const char * sampling_period_str;
     const char * builtins_str;
     const char * depth_str;
@@ -112,6 +114,8 @@ static void init_config(spx_config_t * config, int cli)
 
     config->ui_uri = NULL;
 
+    config->auto_start = 1;
+
     config->sampling_period = 0;
     config->builtins = 0;
     config->max_depth = 0;
@@ -143,6 +147,7 @@ static void fix_config(spx_config_t * config, int cli)
     }
 
     if (!cli) {
+        config->auto_start = 1;
         config->report = SPX_CONFIG_REPORT_FULL;
     }
 
@@ -161,6 +166,7 @@ static void source_data_get(source_data_t * source_data, source_handler_t handle
     source_data->enabled_str          = handler("SPX_ENABLED");
     source_data->key_str              = handler("SPX_KEY");
     source_data->ui_uri_str           = handler("SPX_UI_URI");
+    source_data->auto_start_str       = handler("SPX_AUTO_START");
     source_data->sampling_period_str  = handler("SPX_SAMPLING_PERIOD");
     source_data->builtins_str         = handler("SPX_BUILTINS");
     source_data->depth_str            = handler("SPX_DEPTH");
@@ -188,6 +194,10 @@ static void source_data_to_config(const source_data_t * source_data, spx_config_
 
     if (source_data->ui_uri_str) {
         config->ui_uri = source_data->ui_uri_str;
+    }
+
+    if (source_data->auto_start_str) {
+        config->auto_start = *source_data->auto_start_str == '1' ? 1 : 0;
     }
 
     if (source_data->sampling_period_str) {

--- a/src/spx_config.h
+++ b/src/spx_config.h
@@ -34,6 +34,8 @@ typedef struct {
 
     const char * ui_uri;
 
+    int auto_start;
+
     size_t sampling_period;
     int builtins;
     size_t max_depth;

--- a/src/spx_php.c
+++ b/src/spx_php.c
@@ -137,6 +137,7 @@ static SPX_THREAD_TLS struct {
     const char * active_function_name;
 } context;
 
+static void execute_data_function(const zend_execute_data * execute_data, spx_php_function_t * function TSRMLS_DC);
 static void reset_context(void);
 
 #if ZEND_MODULE_API_NO >= 20151012
@@ -199,111 +200,7 @@ void spx_php_current_function(spx_php_function_t * function)
         function->class_name = "";
         function->func_name = context.active_function_name;
     } else {
-        if (zend_is_executing(TSRMLS_C)) {
-#if ZEND_MODULE_API_NO >= 20151012
-            const zend_function * func = EG(current_execute_data)->func;
-            switch (func->type) {
-                case ZEND_USER_FUNCTION:
-                case ZEND_INTERNAL_FUNCTION:
-                {
-                    const zend_class_entry * ce = func->common.scope;
-                    if (ce) {
-                        function->class_name = ZSTR_VAL(ce->name);
-                    }
-                }
-            }
-
-            switch (func->type) {
-                case ZEND_USER_FUNCTION:
-                {
-                    zend_string * function_name = func->common.function_name;
-                    if (function_name) {
-                        function->func_name = ZSTR_VAL(function_name);
-                    }
-
-                    break;
-                }
-
-                case ZEND_INTERNAL_FUNCTION:
-                    function->func_name = ZSTR_VAL(func->common.function_name);
-            }
-#else
-            switch (EG(current_execute_data)->function_state.function->type) {
-                case ZEND_USER_FUNCTION:
-                case ZEND_INTERNAL_FUNCTION:
-                {
-                    zend_class_entry *ce = EG(current_execute_data)->function_state.function->common.scope;
-                    if (ce) {
-                        function->class_name = ce->name;
-                    }
-                }
-            }
-
-            switch (EG(current_execute_data)->function_state.function->type) {
-                case ZEND_USER_FUNCTION:
-                {
-                    const char * function_name = (
-                            (zend_op_array *) EG(current_execute_data)->function_state.function
-                        )
-                        ->function_name
-                    ;
-
-                    if (function_name) {
-                        function->func_name = function_name;
-                    }
-
-                    break;
-                }
-                case ZEND_INTERNAL_FUNCTION:
-                    function->func_name = (
-                            (zend_internal_function *) EG(current_execute_data)->function_state.function
-                        )
-                        ->function_name
-                    ;
-            }
-#endif
-
-#if ZEND_MODULE_API_NO >= 20151012
-            /*
-             *  Required for PHP 7+ to avoid function name default'd to "main" in this case
-             *  (including file level code).
-             *  See get_active_function_name() implementation in php-src.
-             */
-            if (func->type == ZEND_USER_FUNCTION && !func->common.function_name) {
-                function->func_name = "";
-            }
-            /*
-             *  This hack is required for PHP 7.1 to prevent a segfault while dereferencing function->func_name
-             *  TODO: open an issue if not yet tracked
-             */
-            if (func->type == ZEND_INTERNAL_FUNCTION && !func->common.function_name) {
-                function->func_name = "";
-            }
-#endif
-        }
-
-        if (!function->func_name[0]) {
-            function->class_name = "";
-
-#if ZEND_MODULE_API_NO >= 20151012
-            const zend_execute_data * ex = EG(current_execute_data);
-            while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {
-                ex = ex->prev_execute_data;
-            }
-
-            if (ex) {
-                function->func_name = ZSTR_VAL(ex->func->op_array.filename);
-            } else {
-                function->func_name = "[no active file]";
-            }
-#else
-            if (EG(active_op_array)) {
-                function->func_name = EG(active_op_array)->filename;
-            } else {
-                function->func_name = "[no active file]";
-            }
-#endif
-        }
+        execute_data_function(EG(current_execute_data), function TSRMLS_CC);
     }
 
     function->hash_code =
@@ -673,6 +570,8 @@ void spx_php_execution_finalize(void)
         context.ex_hook.internal.after();
         context.active_function_name = NULL;
     }
+
+    context.request_shutdown = 0;
 }
 
 void spx_php_execution_init(void)
@@ -867,6 +766,114 @@ void spx_php_log_notice(const char * fmt, ...)
     zend_error(E_NOTICE, "SPX: %s", buf);
 
     free(buf);
+}
+
+static void execute_data_function(const zend_execute_data * execute_data, spx_php_function_t * function TSRMLS_DC)
+{
+    if (zend_is_executing(TSRMLS_C)) {
+#if ZEND_MODULE_API_NO >= 20151012
+        const zend_function * func = execute_data->func;
+        switch (func->type) {
+            case ZEND_USER_FUNCTION:
+            case ZEND_INTERNAL_FUNCTION:
+            {
+                const zend_class_entry * ce = func->common.scope;
+                if (ce) {
+                    function->class_name = ZSTR_VAL(ce->name);
+                }
+            }
+        }
+
+        switch (func->type) {
+            case ZEND_USER_FUNCTION:
+            {
+                zend_string * function_name = func->common.function_name;
+                if (function_name) {
+                    function->func_name = ZSTR_VAL(function_name);
+                }
+
+                break;
+            }
+
+            case ZEND_INTERNAL_FUNCTION:
+                function->func_name = ZSTR_VAL(func->common.function_name);
+        }
+#else
+        switch (execute_data->function_state.function->type) {
+            case ZEND_USER_FUNCTION:
+            case ZEND_INTERNAL_FUNCTION:
+            {
+                zend_class_entry *ce = execute_data->function_state.function->common.scope;
+                if (ce) {
+                    function->class_name = ce->name;
+                }
+            }
+        }
+
+        switch (execute_data->function_state.function->type) {
+            case ZEND_USER_FUNCTION:
+            {
+                const char * function_name = (
+                        (zend_op_array *) execute_data->function_state.function
+                    )
+                    ->function_name
+                ;
+
+                if (function_name) {
+                    function->func_name = function_name;
+                }
+
+                break;
+            }
+            case ZEND_INTERNAL_FUNCTION:
+                function->func_name = (
+                        (zend_internal_function *) execute_data->function_state.function
+                    )
+                    ->function_name
+                ;
+        }
+#endif
+
+#if ZEND_MODULE_API_NO >= 20151012
+        /*
+         *  Required for PHP 7+ to avoid function name default'd to "main" in this case
+         *  (including file level code).
+         *  See get_active_function_name() implementation in php-src.
+         */
+        if (func->type == ZEND_USER_FUNCTION && !func->common.function_name) {
+            function->func_name = "";
+        }
+        /*
+         *  This hack is required for PHP 7.1 to prevent a segfault while dereferencing function->func_name
+         *  TODO: open an issue if not yet tracked
+         */
+        if (func->type == ZEND_INTERNAL_FUNCTION && !func->common.function_name) {
+            function->func_name = "";
+        }
+#endif
+    }
+
+    if (!function->func_name[0]) {
+        function->class_name = "";
+
+#if ZEND_MODULE_API_NO >= 20151012
+        while (execute_data && (!execute_data->func || !ZEND_USER_CODE(execute_data->func->type))) {
+            execute_data = execute_data->prev_execute_data;
+        }
+
+        if (execute_data) {
+            function->func_name = ZSTR_VAL(execute_data->func->op_array.filename);
+        } else {
+            function->func_name = "[no active file]";
+        }
+#else
+        if (EG(active_op_array)) {
+            function->func_name = EG(active_op_array)->filename;
+        } else {
+            function->func_name = "[no active file]";
+        }
+#endif
+    }
 }
 
 static void reset_context(void)

--- a/tests/spx_auto_start_001.phpt
+++ b/tests/spx_auto_start_001.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Auto start disabled
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+END;
+--FILE--
+<?php
+echo 'Normal output';
+?>
+--EXPECT--
+Normal output

--- a/tests/spx_auto_start_002.phpt
+++ b/tests/spx_auto_start_002.phpt
@@ -1,0 +1,98 @@
+--TEST--
+Auto start disabled, builtins traced, trace report & several traced spans
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_METRICS=zo
+SPX_BUILTINS=1
+SPX_REPORT=trace
+SPX_TRACE_FILE=/dev/stdout
+SPX_TRACE_SAFE=1
+END;
+--FILE--
+<?php
+echo "Normal output\n";
+
+$objects = [];
+
+function foo() {
+    global $objects;
+
+    $objects[] = new stdClass();
+    bar();
+    $objects[] = new stdClass();
+}
+
+function bar() {
+    global $objects;
+
+    $objects[] = new stdClass();
+    time();
+
+    spx_profiler_start();
+
+    $objects[] = new stdClass();
+    time();
+}
+
+for ($i = 0; $i < 3; $i++) {
+    foo();
+    $objects[] = new stdClass();
+    spx_profiler_stop();
+}
+
+?>
+--EXPECTF--
+Normal output
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_002.php
+        0 |        0 |        0 |        2 |  +foo
+        0 |        0 |        0 |        3 |   +bar
+        0 |        0 |        0 |        4 |    +spx_profiler_start
+        0 |        0 |        0 |        4 |    -spx_profiler_start
+        1 |        0 |        0 |        4 |    +time
+        1 |        0 |        0 |        4 |    -time
+        1 |        1 |        1 |        3 |   -bar
+        2 |        2 |        1 |        2 |  -foo
+        3 |        0 |        0 |        2 |  +spx_profiler_stop
+        3 |        0 |        0 |        2 |  -spx_profiler_stop
+        3 |        3 |        1 |        1 | -%s/spx_auto_start_002.php
+
+SPX trace file: /dev/stdout
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_002.php
+        0 |        0 |        0 |        2 |  +foo
+        0 |        0 |        0 |        3 |   +bar
+        0 |        0 |        0 |        4 |    +spx_profiler_start
+        0 |        0 |        0 |        4 |    -spx_profiler_start
+        1 |        0 |        0 |        4 |    +time
+        1 |        0 |        0 |        4 |    -time
+        1 |        1 |        1 |        3 |   -bar
+        2 |        2 |        1 |        2 |  -foo
+        3 |        0 |        0 |        2 |  +spx_profiler_stop
+        3 |        0 |        0 |        2 |  -spx_profiler_stop
+        3 |        3 |        1 |        1 | -%s/spx_auto_start_002.php
+
+SPX trace file: /dev/stdout
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_002.php
+        0 |        0 |        0 |        2 |  +foo
+        0 |        0 |        0 |        3 |   +bar
+        0 |        0 |        0 |        4 |    +spx_profiler_start
+        0 |        0 |        0 |        4 |    -spx_profiler_start
+        1 |        0 |        0 |        4 |    +time
+        1 |        0 |        0 |        4 |    -time
+        1 |        1 |        1 |        3 |   -bar
+        2 |        2 |        1 |        2 |  -foo
+        3 |        0 |        0 |        2 |  +spx_profiler_stop
+        3 |        0 |        0 |        2 |  -spx_profiler_stop
+        3 |        3 |        1 |        1 | -%s/spx_auto_start_002.php
+
+SPX trace file: /dev/stdout

--- a/tests/spx_auto_start_003.phpt
+++ b/tests/spx_auto_start_003.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Auto start disabled, no builtins traced, trace report & several traced spans
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_METRICS=zo
+SPX_BUILTINS=0
+SPX_REPORT=trace
+SPX_TRACE_FILE=/dev/stdout
+SPX_TRACE_SAFE=1
+END;
+--FILE--
+<?php
+echo "Normal output\n";
+
+$objects = [];
+
+function foo() {
+    global $objects;
+
+    $objects[] = new stdClass();
+    bar();
+    $objects[] = new stdClass();
+}
+
+function bar() {
+    global $objects;
+
+    $objects[] = new stdClass();
+    time();
+
+    spx_profiler_start();
+
+    $objects[] = new stdClass();
+    time();
+}
+
+for ($i = 0; $i < 3; $i++) {
+    foo();
+    $objects[] = new stdClass();
+    spx_profiler_stop();
+}
+
+?>
+--EXPECTF--
+Normal output
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_003.php
+        0 |        0 |        0 |        2 |  +foo
+        0 |        0 |        0 |        3 |   +bar
+        1 |        1 |        1 |        3 |   -bar
+        2 |        2 |        1 |        2 |  -foo
+        3 |        3 |        1 |        1 | -%s/spx_auto_start_003.php
+
+SPX trace file: /dev/stdout
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_003.php
+        0 |        0 |        0 |        2 |  +foo
+        0 |        0 |        0 |        3 |   +bar
+        1 |        1 |        1 |        3 |   -bar
+        2 |        2 |        1 |        2 |  -foo
+        3 |        3 |        1 |        1 | -%s/spx_auto_start_003.php
+
+SPX trace file: /dev/stdout
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_003.php
+        0 |        0 |        0 |        2 |  +foo
+        0 |        0 |        0 |        3 |   +bar
+        1 |        1 |        1 |        3 |   -bar
+        2 |        2 |        1 |        2 |  -foo
+        3 |        3 |        1 |        1 | -%s/spx_auto_start_003.php
+
+SPX trace file: /dev/stdout

--- a/tests/spx_auto_start_004.phpt
+++ b/tests/spx_auto_start_004.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Auto start disabled, with nested spans
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_METRICS=zo
+SPX_BUILTINS=0
+SPX_REPORT=trace
+SPX_TRACE_FILE=/dev/stdout
+SPX_TRACE_SAFE=1
+END;
+--FILE--
+<?php
+echo "Normal output\n";
+
+$objects = [];
+
+function foo() {
+    global $objects;
+
+    $objects[] = new stdClass();
+    bar();
+    $objects[] = new stdClass();
+
+    spx_profiler_start();
+
+    spx_profiler_stop();
+}
+
+function bar() {
+    global $objects;
+
+    $objects[] = new stdClass();
+    time();
+
+	spx_profiler_start();
+
+    $objects[] = new stdClass();
+    time();
+
+    spx_profiler_stop();
+}
+
+spx_profiler_start();
+
+foo();
+
+?>
+--EXPECTF--
+Normal output
+ ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Function
+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 | +%s/spx_auto_start_004.php
+        0 |        0 |        0 |        2 |  +foo
+        1 |        0 |        0 |        3 |   +bar
+        3 |        2 |        2 |        3 |   -bar
+        4 |        4 |        2 |        2 |  -foo
+        4 |        4 |        0 |        1 | -%s/spx_auto_start_004.php
+
+SPX trace file: /dev/stdout


### PR DESCRIPTION
This patch adds the support for self-code instrumentation in order
to let the user to trigger the profiling for a specific part of
the script at runtime.

The 2 following userland functions are added:
- `spx_profiler_start(): void`
- `spx_profiler_stop(): void`

This feature requires the PHP script to be configured with:
- SPX_ENABLED=1
- SPX_AUTO_START=0 -> this is a newly added parameter (with `1` as
    default value) for the purpose of this feature.

See the updated documentation for more details.

Resolves #107