### PR TITLE
Report analysis screen: add function highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,14 @@ Metrics corresponding to releasable resources (memory, objects in use...) are no
 
 ![Showcase](https://github.com/NoiseByNorthwest/NoiseByNorthwest.github.io/blob/d8a90827d6eb256f49d580de448b6b6fad4119ac/php-spx/doc/as-fg.png)
 
+
+##### Function highlighting
+
+You can highlight a function by clicking on one of its spans within the timeline or Flamegraph widgets or its name within the flat profile widget.
+
+![Showcase](https://github.com/NoiseByNorthwest/NoiseByNorthwest.github.io/blob/47d8f8d93fad1e6659c46c47e5aa8f82822454a9/php-spx/doc/as-fh.png)
+
+
 ## Security concern
 
 _The lack of review / feedback about this concern is the main reason **SPX cannot yet be considered as production ready**._

--- a/assets/web-ui/js/math.js
+++ b/assets/web-ui/js/math.js
@@ -65,6 +65,14 @@ export class Vec3 {
         return this;
     }
 
+    mult(v) {
+        this.x *= v;
+        this.y *= v;
+        this.z *= v;
+
+        return this;
+    }
+
     toHTMLColor() {
         const c = this.copy().bound();
 
@@ -73,6 +81,16 @@ export class Vec3 {
             parseInt(c.y * 255),
             parseInt(c.z * 255),
         ].join(',') + ')';
+    }
+
+    static createFromHTMLColor(htmlColor) {
+        const matches = /rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/.exec(htmlColor);
+
+        return this.createFromRGB888(
+            matches[1],
+            matches[2],
+            matches[3]
+        );
     }
 
     static createFromRGB888(r, g, b) {


### PR DESCRIPTION
This patch adds the possibility, within the report analysis screen,
to highlight a function by clicking on one of its spans within the
timeline or Flamegraph widgets or on its name within the flat
profile widget.