### PR TITLE
Report analysis: use chunked arrays

### DIFF
--- a/assets/web-ui/js/profileData.js
+++ b/assets/web-ui/js/profileData.js
@@ -308,7 +308,7 @@ class TruncatedCallListEntry extends CallListEntry {
 
 class CallList {
 
-    constructor(size, functionCount, metrics) {
+    constructor(functionCount, metrics) {
         this.metrics = metrics;
         this.functionNames = Array(functionCount).fill("n/a");
 
@@ -331,7 +331,7 @@ class CallList {
             structure['exc_'   + metric] = 'float64';
         }
 
-        this.array = new utils.PackedRecordArray(structure, size);
+        this.array = new utils.ChunkedRecordArray(structure, 1024 * 1024);
     }
 
     getSize() {
@@ -423,7 +423,7 @@ class CumCostStats {
 //       keep in mind that Sample might be to concrete since MetricValueSet can also represent a cost
 class MetricValuesList {
 
-    constructor(size, metrics) {
+    constructor(metrics) {
         this.metrics = metrics;
 
         const structure = {};
@@ -431,7 +431,7 @@ class MetricValuesList {
             structure[metric] = 'float64';
         }
 
-        this.array = new utils.PackedRecordArray(structure, size);
+        this.array = new utils.ChunkedRecordArray(structure, 1024 * 1024);
     }
 
     setRawMetricValuesData(idx, rawMetricValuesData) {
@@ -1240,13 +1240,11 @@ export class ProfileDataBuilder {
         this.currentCallCount = 0;
 
         this.callList = new CallList(
-            metadata.recorded_call_count,
             metadata.called_function_count,
             this.metrics
         );
 
         this.metricValuesList = new MetricValuesList(
-            metadata.recorded_call_count * 2,
             this.metrics
         );
 
@@ -1322,6 +1320,7 @@ export class ProfileDataBuilder {
         }
 
         this.currentCallCount++;
+
         this.callList.setRawCallData(
             frame.idx,
             frame.fnIdx,

--- a/assets/web-ui/js/utils.js
+++ b/assets/web-ui/js/utils.js
@@ -223,6 +223,50 @@ export class PackedRecordArray {
     }
 }
 
+export class ChunkedRecordArray {
+
+    constructor(fields, chunkSize) {
+        this.fields = fields;
+        this.chunkSize = chunkSize;
+        this.chunks = [];
+        this.size = 0;
+    }
+
+    resize(newSize) {
+        const chunkCount = Math.ceil(newSize / this.chunkSize);
+        for (let i = this.chunks.length; i < chunkCount; i++) {
+            this.chunks.push(new PackedRecordArray(this.fields, this.chunkSize));
+        }
+
+        this.size = newSize;
+    }
+
+    getSize() {
+        return this.size;
+    }
+
+    setElement(idx, obj) {
+        if (idx + 1 > this.getSize()) {
+            this.resize(idx + 1);
+        }
+
+        this.chunks[Math.floor(idx / this.chunkSize)].setElement(idx % this.chunkSize, obj);
+    }
+
+    setElementFieldValue(idx, fieldName, fieldValue) {
+        this.chunks[Math.floor(idx / this.chunkSize)].setElementFieldValue(idx % this.chunkSize, fieldName, fieldValue);
+    }
+
+    getElement(idx) {
+        return this.chunks[Math.floor(idx / this.chunkSize)].getElement(idx % this.chunkSize);
+    }
+
+    getElementFieldValue(idx, fieldName) {
+        return this.chunks[Math.floor(idx / this.chunkSize)].getElementFieldValue(idx % this.chunkSize, fieldName);
+    }
+}
+
+
 /*
     FIXME move all categories related stuff elsewhere (e.g. in a dedicated module)
 */


### PR DESCRIPTION
This patch makes the report analysis screen not dependant anymore
of big arrays. It now uses chunked arrays (i.e. multi-buffers backed
arrays) in order to circumvent the ArrayBuffer size limit (2^31 - 1).

References #123