### PR TITLE
ext/build: Add --with-zlib-dir argument support

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,11 @@
 PHP_ARG_ENABLE(SPX, whether to enable SPX extension,
 [ --enable-spx   Enable SPX extension])
 
+if test -z "$PHP_ZLIB_DIR"; then
+PHP_ARG_WITH(zlib-dir, for ZLIB,
+[  --with-zlib-dir[=DIR]   Set the path to ZLIB install prefix.], no)
+fi
+
 if test "$PHP_SPX" = "yes"; then
     if test "$PHP_THREAD_SAFETY" != "no" -a "$CONTINUOUS_INTEGRATION" != "true"
     then
@@ -16,33 +21,35 @@ if test "$PHP_SPX" = "yes"; then
     fi
 
     AC_MSG_CHECKING([for zlib header])
-
-    for dir in /usr/local /usr
-    do
-        for incdir in $dir/include/zlib $dir/include
-        do
-            if test -f "$incdir/zlib.h"
-            then
-                SPX_ZLIB_DIR="$dir"
-                SPX_ZLIB_INCDIR="$incdir"
-
-                break
+    if test "$PHP_ZLIB_DIR" != "no" && test "$PHP_ZLIB_DIR" != "yes"; then
+        if test -f "$PHP_ZLIB_DIR/include/zlib/zlib.h"; then
+            PHP_ZLIB_DIR="$PHP_ZLIB_DIR"
+            PHP_ZLIB_INCDIR="$PHP_ZLIB_DIR/include/zlib"
+        elif test -f "$PHP_ZLIB_DIR/include/zlib.h"; then
+            PHP_ZLIB_DIR="$PHP_ZLIB_DIR"
+            PHP_ZLIB_INCDIR="$PHP_ZLIB_DIR/include"
+        else
+            AC_MSG_ERROR([Can't find ZLIB headers under "$PHP_ZLIB_DIR"])
+        fi
+    else
+        for i in /usr/local /usr; do
+            if test -f "$i/include/zlib/zlib.h"; then
+                PHP_ZLIB_DIR="$i"
+                PHP_ZLIB_INCDIR="$i/include/zlib"
+            elif test -f "$i/include/zlib.h"; then
+                PHP_ZLIB_DIR="$i"
+                PHP_ZLIB_INCDIR="$i/include"
             fi
         done
+    fi
 
-        if test "$SPX_ZLIB_INCDIR" != ""
-        then
-            break
-        fi
-    done
-
-    if test "$SPX_ZLIB_INCDIR" != ""
-    then
-        AC_MSG_RESULT([yes])
-        PHP_ADD_INCLUDE($SPX_ZLIB_INCDIR)
-        PHP_ADD_LIBRARY_WITH_PATH(z, $SPX_ZLIB_DIR/$PHP_LIBDIR, SPX_SHARED_LIBADD)
+    AC_MSG_CHECKING([for zlib location])
+    if test "$PHP_ZLIB_DIR" != "no" && test "$PHP_ZLIB_DIR" != "yes"; then
+        AC_MSG_RESULT([$PHP_ZLIB_DIR])
+        PHP_ADD_LIBRARY_WITH_PATH(z, $PHP_ZLIB_DIR/$PHP_LIBDIR, SPX_SHARED_LIBADD)
+        PHP_ADD_INCLUDE($PHP_ZLIB_INCDIR)
     else
-        AC_MSG_ERROR([Cannot find zlib.h])
+        AC_MSG_ERROR([spx support requires ZLIB. Use --with-zlib-dir=<DIR> to specify the prefix where ZLIB headers and library are located])
     fi
 
     PHP_NEW_EXTENSION(spx,


### PR DESCRIPTION
This fixes build under macOS (brew), where zlib.h is not under /usr/include or /usr/local/include.

Refs:
- https://github.com/glensc/homebrew-tap/pull/8