### PR TITLE
Make compilation succeed with gnu90

### DIFF
--- a/src/spx_resource_stats-linux.c
+++ b/src/spx_resource_stats-linux.c
@@ -115,7 +115,8 @@ size_t spx_resource_stats_own_rss(void)
     size_t stat_name_start = 0;
     int reading_rss_anonymous = 0;
     size_t rss_anonymous = 0;
-    for (size_t i = 0; i < sizeof(context.lg_buf); i++) {
+    size_t i;
+    for (i = 0; i < sizeof(context.lg_buf); i++) {
         const char c = context.lg_buf[i];
         if (c == '\n') {
             if (reading_rss_anonymous) {


### PR DESCRIPTION
Fixes the following compilation error (see #121):

src/spx_resource_stats-linux.c: In function 'spx_resource_stats_own_rss':
src/spx_resource_stats-linux.c:118:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizeof(context.lg_buf); i++) {
     ^
src/spx_resource_stats-linux.c:118:5: note: use option -std=c99 or -std=gnu99 to compile your code