### PR TITLE
Force -std=gnu90 compilation flag

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -14,7 +14,7 @@ if test "$PHP_SPX" = "yes"; then
 
     AC_DEFINE(HAVE_SPX, 1, [spx])
 
-    CFLAGS="-Werror -Wall -O3 -pthread"
+    CFLAGS="-Werror -Wall -O3 -pthread -std=gnu90"
     if test "$CONTINUOUS_INTEGRATION" = "true"
     then
         CFLAGS="$CFLAGS -DCONTINUOUS_INTEGRATION"


### PR DESCRIPTION
gnu90 appears to be the best standard to enforce right now, regarding both its cost (in terms of lack of feature) and its support being widespread.

Forcing gnu90 as explicit standard to enforce will avoid issues like #121 & #146 in the future.