### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Well, as you might already noticed in corresponding [basic usage example](#comma
 
 Since the web UI uses advanced JavaScript features, only the following browsers are known to be supported:
 - most recent version of any Chromium-based browser.
-- most recent version of Firefox with `dom.moduleScripts.enabled` preference set to `true`.
+- most recent version of Firefox.
 
 #### Control panel & report list
 


### PR DESCRIPTION
dom.moduleScripts.enabled are true by default since Firefox 60 (May 9 2018): https://developer.mozilla.org/nl/docs/Mozilla/Firefox/Releases/60#JavaScript