### PR TITLE
Build specific version of php-spx instead of latest commit on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Current requirements are:
 ```shell
 git clone https://github.com/NoiseByNorthwest/php-spx.git
 cd php-spx
+git checkout tags/v0.4.10
 phpize
 ./configure
 make

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Current requirements are:
 ```shell
 git clone https://github.com/NoiseByNorthwest/php-spx.git
 cd php-spx
-git checkout tags/v0.4.10
+git checkout release/latest
 phpize
 ./configure
 make


### PR DESCRIPTION
It's probably better to build php-spx using the latest released version.