### PR TITLE
Open reports in a new tab

### DIFF
--- a/assets/web-ui/js/dataTable.js
+++ b/assets/web-ui/js/dataTable.js
@@ -57,7 +57,7 @@ export function makeDataTable(containerId, options, rows) {
                 }
 
                 if (url) {
-                    value = `<a href="${url}">${value}</a>`;
+                    value = `<a target="_blank" href="${url}">${value}</a>`;
                 }
 
                 html += `<td class="${column.cssClass || ''}">${value}</td>`;


### PR DESCRIPTION
This change, will make clicking a report open a new tab or window, instead of opening it in the current.