### PR TITLE
Enable Release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,16 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
+    tags:
+      - '*'
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
     branches:
       - master
-  tags:
-      - '*'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
       - '**.md'
       - '**.txt'
   pull_request:
+    branches:
+      - master
+  tags:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,5 +148,5 @@ jobs:
           tag: ${{ steps.get-version.outputs.version }}
           bodyFile: "./release-notes.md"
           allowUpdates: true
-          artifacts: "./build-artifacts/*.zip"
+          artifacts: "./build-artifacts/*/*.zip"
           artifactContentType: application/octet-stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.0...HEAD)
+## [Unreleased](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.13...HEAD)
+
+
+## [v0.4.13](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.12...0.4.13)
 
 ### Added
 - Github Actions workflow ([#180](https://github.com/NoiseByNorthwest/php-spx/issues/180))
+- Added support for php 8.2.0 RC2 [#198](https://github.com/NoiseByNorthwest/php-spx/issues/198)
+- Added PHP 8.2 support [#196](https://github.com/NoiseByNorthwest/php-spx/issues/196)
+
+### Changed
+- Documentation: Clarified what Inc. and Exc. mean in the table [#193](https://github.com/NoiseByNorthwest/php-spx/issues/193)
 
 ### Removed
-- Travis CI
+- Travis CI [#195](https://github.com/NoiseByNorthwest/php-spx/issues/195)
 
 
 ## [v0.4.0](https://github.com/NoiseByNorthwest/php-spx/compare/0.3.0...0.4.0)

--- a/src/php_spx.h
+++ b/src/php_spx.h
@@ -40,6 +40,6 @@
 #endif
 
 #define PHP_SPX_EXTNAME "SPX"
-#define PHP_SPX_VERSION "0.4.12"
+#define PHP_SPX_VERSION "0.4.13"
 
 extern zend_module_entry spx_module_entry;


### PR DESCRIPTION
Hi @NoiseByNorthwest 

I forgot to enable Release action in PR #190, so this PR will fix this. Also I've bumped SPX version from 0.4.12 to v0.4.13

You can see how it works in my fork:
[Release](https://github.com/AlexNDRmac/php-spx/releases/tag/v0.4.13-test2)
[Action run](https://github.com/AlexNDRmac/php-spx/actions/runs/3145724831/jobs/5113396847)

After merging this PR - you'll be able to create Release with pushing tag or just manually creating Release as usually. Action will build all the artifacts, creates release notes from Changelog.md details, attach all the build artifacts (compiled extension with web-ui for each PHP version) to the release assets.