### PR TITLE
Path in test is different for releases

### DIFF
--- a/tests/spx_custom_metadata.phpt
+++ b/tests/spx_custom_metadata.phpt
@@ -43,9 +43,9 @@ foreach ($metadataStrings as $metadataString) {
   "host_name": "%s",
   "process_pid": %d,
   "process_tid": %d,
-  "process_pwd": "%s\/php-spx",
+  "process_pwd": "%s\/php-spx%s",
   "cli": 1,
-  "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
+  "cli_command_line": "%s\/php-spx%s\/tests\/spx_custom_metadata.php",
   "http_request_uri": "n\/a",
   "http_method": "GET",
   "http_host": "n\/a",
@@ -66,9 +66,9 @@ foreach ($metadataStrings as $metadataString) {
   "host_name": "%s",
   "process_pid": %d,
   "process_tid": %d,
-  "process_pwd": "%s\/php-spx",
+  "process_pwd": "%s\/php-spx%s",
   "cli": 1,
-  "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
+  "cli_command_line": "%s\/php-spx%s\/tests\/spx_custom_metadata.php",
   "http_request_uri": "n\/a",
   "http_method": "GET",
   "http_host": "n\/a",
@@ -89,9 +89,9 @@ foreach ($metadataStrings as $metadataString) {
   "host_name": "%s",
   "process_pid": %d,
   "process_tid": %d,
-  "process_pwd": "%s\/php-spx",
+  "process_pwd": "%s\/php-spx%s",
   "cli": 1,
-  "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
+  "cli_command_line": "%s\/php-spx%s\/tests\/spx_custom_metadata.php",
   "http_request_uri": "n\/a",
   "http_method": "GET",
   "http_host": "n\/a",
@@ -106,18 +106,18 @@ foreach ($metadataStrings as $metadataString) {
     ,"zm"
   ]
 }
-PHP Notice:  SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in %s/php-spx/tests/spx_custom_metadata.php on line 18
+PHP Notice:  SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in %s/php-spx%s/tests/spx_custom_metadata.php on line 18
 
-Notice: SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in %s/php-spx/tests/spx_custom_metadata.php on line 18
+Notice: SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in %s/php-spx%s/tests/spx_custom_metadata.php on line 18
 {
   "key": "spx-full-%s",
   "exec_ts": %d,
   "host_name": "%s",
   "process_pid": %d,
   "process_tid": %d,
-  "process_pwd": "%s\/php-spx",
+  "process_pwd": "%s\/php-spx%s",
   "cli": 1,
-  "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
+  "cli_command_line": "%s\/php-spx%s\/tests\/spx_custom_metadata.php",
   "http_request_uri": "n\/a",
   "http_method": "GET",
   "http_host": "n\/a",
@@ -138,9 +138,9 @@ Notice: SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $cust
   "host_name": "%s",
   "process_pid": %d,
   "process_tid": %d,
-  "process_pwd": "%s\/php-spx",
+  "process_pwd": "%s\/php-spx%s",
   "cli": 1,
-  "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
+  "cli_command_line": "%s\/php-spx%s\/tests\/spx_custom_metadata.php",
   "http_request_uri": "n\/a",
   "http_method": "GET",
   "http_host": "n\/a",


### PR DESCRIPTION
Using to build latest release I got one test failed because test does not expect path with suffix for release

```
TEST 28/45 [tests/spx_custom_metadata.phpt]
========DIFF========
--
       "host_name": "%s",
       "process_pid": %d,
       "process_tid": %d,
007+   "process_pwd": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14",
007-   "process_pwd": "%s\/php-spx",
       "cli": 1,
009+   "cli_command_line": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14\/tests\/spx_custom_metadata.php",
009-   "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
       "http_request_uri": "n\/a",
       "http_method": "GET",
       "http_host": "n\/a",
--
       "host_name": "%s",
       "process_pid": %d,
       "process_tid": %d,
030+   "process_pwd": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14",
030-   "process_pwd": "%s\/php-spx",
       "cli": 1,
032+   "cli_command_line": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14\/tests\/spx_custom_metadata.php",
032-   "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
       "http_request_uri": "n\/a",
       "http_method": "GET",
       "http_host": "n\/a",
--
       "host_name": "%s",
       "process_pid": %d,
       "process_tid": %d,
053+   "process_pwd": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14",
053-   "process_pwd": "%s\/php-spx",
       "cli": 1,
055+   "cli_command_line": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14\/tests\/spx_custom_metadata.php",
055-   "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
       "http_request_uri": "n\/a",
       "http_method": "GET",
       "http_host": "n\/a",
--
         ,"zm"
       ]
     }
070+ PHP Notice:  SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in /mnt/testing/php81-spx/src/php-spx-0.4.14/tests/spx_custom_metadata.php on line 18
070- PHP Notice:  SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in %s/php-spx/tests/spx_custom_metadata.php on line 18
     
072+ Notice: SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in /mnt/testing/php81-spx/src/php-spx-0.4.14/tests/spx_custom_metadata.php on line 18
072- Notice: SPX: spx_profiler_full_report_set_custom_metadata_str(): too large $customMetadataStr string, it must not exceed 4KB in %s/php-spx/tests/spx_custom_metadata.php on line 18
     {
       "key": "spx-full-%s",
       "exec_ts": %d,
       "host_name": "%s",
       "process_pid": %d,
       "process_tid": %d,
079+   "process_pwd": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14",
079-   "process_pwd": "%s\/php-spx",
       "cli": 1,
081+   "cli_command_line": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14\/tests\/spx_custom_metadata.php",
081-   "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
       "http_request_uri": "n\/a",
       "http_method": "GET",
       "http_host": "n\/a",
--
       "host_name": "%s",
       "process_pid": %d,
       "process_tid": %d,
102+   "process_pwd": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14",
102-   "process_pwd": "%s\/php-spx",
       "cli": 1,
104+   "cli_command_line": "\/mnt\/testing\/php81-spx\/src\/php-spx-0.4.14\/tests\/spx_custom_metadata.php",
104-   "cli_command_line": "%s\/php-spx\/tests\/spx_custom_metadata.php",
       "http_request_uri": "n\/a",
       "http_method": "GET",
       "http_host": "n\/a",
--
========DONE========
FAIL Custom metadata [tests/spx_custom_metadata.phpt] 
```