### PR TITLE
Builds for debian

### DIFF
--- a/.github/workflows/build-debian-ext/Dockerfile
+++ b/.github/workflows/build-debian-ext/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:11.5-slim as builder
+
+LABEL Description="Base image with custom PHP version based on Debian"
+LABEL name="spx-profiler-debian11"
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ARG PHP_VERSION
+
+RUN apt update && apt upgrade -y && \
+    apt install --no-install-recommends -y \
+        lsb-release \
+        ca-certificates \
+        apt-transport-https \
+        software-properties-common \
+        gnupg2 \
+        wget \
+        curl \
+        git \
+        make\
+        zlib1g-dev \
+        && \
+    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/sury-php.list && \
+    wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add - && \
+    apt update && \
+    apt install -y php${PHP_VERSION}-dev

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -11,8 +11,6 @@ runs:
         file: ${{ github.workspace }}/.github/workflows/build-debian-ext/Dockerfile
         build-args: |
           PHP_VERSION=${{ matrix.php }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
 
     - name: Run the build process with Docker
       uses: addnab/docker-run-action@v3

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -12,6 +12,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - uses: docker/build-push-action@v4
       with:
         push: false

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -1,0 +1,27 @@
+name: 'PHP Extension build action'
+description: 'Build PHP extension for debian using docker'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: builder:${{ matrix.php }}
+        file: ${{ github.workspace }}/.github/workflows/build-debian-ext/Dockerfile
+        build-args: |
+          PHP_VERSION=${{ matrix.php }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Run the build process with Docker
+      shell: bash
+      uses: addnab/docker-run-action@v3
+      with:
+          image: builder:${{ matrix.php }}
+          options: -v ${{ github.workspace }}:/php-spx
+          run: |
+              cd /php-spx
+              phpize
+              ./configure
+              make -j"$(getconf _NPROCESSORS_ONLN)"

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -8,7 +8,7 @@ runs:
       with:
         push: false
         tags: builder:${{ matrix.php }}
-        file: ${{ github.workspace }}/.github/workflows/build-debian-ext/Dockerfile
+        file: ./.github/workflows/build-debian-ext/Dockerfile
         build-args: |
           PHP_VERSION=${{ matrix.php }}
 

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -15,13 +15,12 @@ runs:
         cache-to: type=gha,mode=max
 
     - name: Run the build process with Docker
-      shell: bash
       uses: addnab/docker-run-action@v3
       with:
-          image: builder:${{ matrix.php }}
-          options: -v ${{ github.workspace }}:/php-spx
-          run: |
-              cd /php-spx
-              phpize
-              ./configure
-              make -j"$(getconf _NPROCESSORS_ONLN)"
+        image: builder:${{ matrix.php }}
+        options: -v ${{ github.workspace }}:/php-spx
+        run: |
+            cd /php-spx
+            phpize
+            ./configure
+            make -j"$(getconf _NPROCESSORS_ONLN)"

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-php${{ matrix.php }}
         restore-keys: |
           ${{ runner.os }}-buildx-
 

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -4,13 +4,29 @@ description: 'Build PHP extension for debian using docker'
 runs:
   using: 'composite'
   steps:
-    - uses: docker/build-push-action@v2
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - uses: docker/build-push-action@v4
       with:
         push: false
         tags: builder:${{ matrix.php }}
         file: ./.github/workflows/build-debian-ext/Dockerfile
         build-args: |
           PHP_VERSION=${{ matrix.php }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+    - name: Move buildx cache
+      shell: bash
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: Run the build process with Docker
       uses: addnab/docker-run-action@v3

--- a/.github/workflows/build-debian-ext/action.yml
+++ b/.github/workflows/build-debian-ext/action.yml
@@ -18,6 +18,7 @@ runs:
     - uses: docker/build-push-action@v4
       with:
         push: false
+        load: true
         tags: builder:${{ matrix.php }}
         file: ./.github/workflows/build-debian-ext/Dockerfile
         build-args: |

--- a/.github/workflows/build-linux-mac-ext/action.yml
+++ b/.github/workflows/build-linux-mac-ext/action.yml
@@ -10,13 +10,16 @@ runs:
         php-version: ${{ matrix.php }}
     
     - name: Install dependencies
+      shell: bash
       if: runner.os == 'macOS'
       run: brew install zlib
 
     - name: phpize
+      shell: bash
       run: phpize
 
     - name: Configure
+      shell: bash
       run: |
         if [ "${{ runner.os }}" = "macOS" ]; then
           ./configure --with-zlib-dir=$(brew --prefix)/opt/zlib
@@ -25,16 +28,19 @@ runs:
         fi
 
     - name: Compile
+      shell: bash
       run: |
         make -j"$(getconf _NPROCESSORS_ONLN)"
         sudo make install
 
     - name: Extension Info
+      shell: bash
       run: |
         php --ini
         php -d extension=./modules/spx.so --ri spx
 
     - name: Run Tests
+      shell: bash
       run: make test
       env:
         NO_INTERACTION: 1

--- a/.github/workflows/build-linux-mac-ext/action.yml
+++ b/.github/workflows/build-linux-mac-ext/action.yml
@@ -1,0 +1,42 @@
+name: 'PHP Extension build action'
+description: 'Build PHP extension for linux/mac'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+    
+    - name: Install dependencies
+      if: runner.os == 'macOS'
+      run: brew install zlib
+
+    - name: phpize
+      run: phpize
+
+    - name: Configure
+      run: |
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          ./configure --with-zlib-dir=$(brew --prefix)/opt/zlib
+        else
+          ./configure
+        fi
+
+    - name: Compile
+      run: |
+        make -j"$(getconf _NPROCESSORS_ONLN)"
+        sudo make install
+
+    - name: Extension Info
+      run: |
+        php --ini
+        php -d extension=./modules/spx.so --ri spx
+
+    - name: Run Tests
+      run: make test
+      env:
+        NO_INTERACTION: 1
+        REPORT_EXIT_STATUS: 1
+        TEST_PHP_ARGS: "--show-diff"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,13 +26,16 @@ jobs:
 
         name:
           - linux
+          - debian
           - mac
 
         include:
           # Linux
-          - { name: linux, ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
+          - { name: linux,  ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
+          # Debian (docker)
+          - { name: debian, ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
           # macOS
-          - { name: mac,   ts: 'nts', compiler: 'clang', os: macos-11 }
+          - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-11 }
 
     steps:
       - uses: actions/checkout@v3
@@ -45,8 +48,13 @@ jobs:
         run: |
           echo "spx_file_name=spx-php-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.name }}-${{ matrix.compiler }}" >> $GITHUB_OUTPUT
 
-      - name: Build extension
-        uses: ./.github/workflows/build-linux-mac-ext          
+      - name: Build extension for Ubuntu and macOS
+        if: ${{ matrix.name }} != 'debian'
+        uses: ./.github/workflows/build-linux-mac-ext
+
+      - name: Build extension for Debian using docker
+        if: ${{ matrix.name }} == 'debian'
+        uses: ./.github/workflows/build-debian-ext
 
       - name: Upload build artifacts after Failure
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,11 +49,11 @@ jobs:
           echo "spx_file_name=spx-php-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.name }}-${{ matrix.compiler }}" >> $GITHUB_OUTPUT
 
       - name: Build extension for Ubuntu and macOS
-        if: ${{ matrix.name }} != 'debian'
+        if: matrix.name != 'debian'
         uses: ./.github/workflows/build-linux-mac-ext
 
       - name: Build extension for Debian using docker
-        if: ${{ matrix.name }} == 'debian'
+        if: matrix.name == 'debian'
         uses: ./.github/workflows/build-debian-ext
 
       - name: Upload build artifacts after Failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
-        php: ['8.1']
+        php: ['5.6', '7.1', '8.1']
 
         name:
           - linux
@@ -31,11 +31,11 @@ jobs:
 
         include:
           # Linux
-          - { name: linux,  ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
+          # - { name: linux,  ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
           # Debian (docker)
           - { name: debian, ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
           # macOS
-          - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-11 }
+          # - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-11 }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,28 +21,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
-        php: ['5.6', '7.1', '8.1']
+        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
 
         name:
-          # - linux
+          - linux
           - debian
-          # - mac
+          - mac
 
         include:
           # Linux
-          # - { name: linux,  ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
+          - { name: linux,  ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
           # Debian (docker)
           - { name: debian, ts: 'nts', compiler: 'gcc',   os: ubuntu-20.04 }
           # macOS
-          # - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-11 }
+          - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-11 }
 
     steps:
       - uses: actions/checkout@v3
 
       # configure spx artifact name in next format:
       #   {php}-{ts}-{os.name}-{compiler}
-      #   spx-php-8.1-nts-Linux-gcc
+      #   spx-php-8.1-nts-linux-gcc
       - name: Set artifact name
         id: setup-artifact
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
         php: ['5.6', '7.1', '8.1']
 
         name:
-          - linux
+          # - linux
           - debian
-          - mac
+          # - mac
 
         include:
           # Linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           - { name: mac,   ts: 'nts', compiler: 'clang', os: macos-11 }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # configure spx artifact name in next format:
       #   {php}-{ts}-{os.name}-{compiler}
@@ -42,7 +42,7 @@ jobs:
       - name: Set artifact name
         id: setup-artifact
         run: |
-          echo "::set-output name=spx_file_name::spx-php-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.name }}-${{ matrix.compiler }}"
+          echo "spx_file_name=spx-php-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.name }}-${{ matrix.compiler }}" >> $GITHUB_OUTPUT
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload build artifacts after Failure
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: debug-${{ steps.setup-artifact.outputs.spx_file_name }}
           path: |
@@ -106,7 +106,7 @@ jobs:
           ./.github/release-notes.sh ./CHANGELOG.md
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.setup-artifact.outputs.spx_file_name }}
           path: ${{ steps.setup-artifact.outputs.spx_file_name }}.zip
@@ -120,18 +120,18 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Get the release version
         id: get-version
         run: |
-          echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Download SPX build artifacts
         id: download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ./build-artifacts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        # php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php: ['8.1']
 
         name:
           - linux
@@ -44,42 +45,8 @@ jobs:
         run: |
           echo "spx_file_name=spx-php-${{ matrix.php }}-${{ matrix.ts }}-${{ matrix.name }}-${{ matrix.compiler }}" >> $GITHUB_OUTPUT
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Install dependencies
-        if: runner.os == 'macOS'
-        run: brew install zlib
-
-      - name: phpize
-        run: phpize
-
-      - name: Configure
-        run: |
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            ./configure --with-zlib-dir=$(brew --prefix)/opt/zlib
-          else
-            ./configure
-          fi
-
-      - name: Compile
-        run: |
-          make -j"$(getconf _NPROCESSORS_ONLN)"
-          sudo make install
-
-      - name: Extension Info
-        run: |
-          php --ini
-          php -d extension=./modules/spx.so --ri spx
-
-      - name: Run Tests
-        run: make test
-        env:
-          NO_INTERACTION: 1
-          REPORT_EXIT_STATUS: 1
-          TEST_PHP_ARGS: "--show-diff"
+      - name: Build extension
+        uses: ./.github/workflows/build-linux-mac-ext          
 
       - name: Upload build artifacts after Failure
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.setup-artifact.outputs.spx_file_name }}
+          name: ${{ steps.setup-artifact.outputs.spx_file_name }}.zip
           path: ${{ steps.setup-artifact.outputs.spx_file_name }}.zip
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.13...HEAD)
+## [Unreleased](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.14...HEAD)
+
+### Added
+- Added Debian builds to github workflow
+
+
+## [v0.4.14](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.13...0.4.14)
+
+### Added
+- Added simple search feature
+- Added custom metadata storage implementation
+- Added `--enable-spx-dev` to compile with debug symbols
+
+### Fixed
+- Fixed buffer overflow in str_builder
 
 
 ## [v0.4.13](https://github.com/NoiseByNorthwest/php-spx/compare/0.4.12...0.4.13)


### PR DESCRIPTION
Hi @NoiseByNorthwest

I've reworked github actions to add Debian builds.
Now, github workflow split on two separate actions. It allows us to compile extension for ubuntu and macos, and build extension for Debian.
Debian users as an Ubuntu users - can download build extension and use it OOB (without compilation)

Also, I've updated Changelog, because it obsolete.