### PR TITLE
Scroll-to-zoom: Make it much smoother

### DIFF
--- a/assets/web-ui/js/widget.js
+++ b/assets/web-ui/js/widget.js
@@ -1126,7 +1126,7 @@ export class TimeLine extends SVGWidget {
             }
 
             e.preventDefault();
-            let f = 1.5;
+            let f = 1 + Math.abs(e.originalEvent.deltaY / 1000);
             if (e.originalEvent.deltaY < 0) {
                 f = 1 / f;
             }


### PR DESCRIPTION
On many systems, touchpads produce *many* small-delta "wheel" events where mouse wheels produce less frequent and larger-delta wheel events.

On my system, the existing setup is unusable because a tiny scroll ends up zooming in ~10x.

Now, we scale the zoom amount by the scroll delta. This change makes the experience so smooth and completely usable.