### PR TITLE
Fix stack tracking in spx_profiler_start()

### DIFF
--- a/src/spx_php.c
+++ b/src/spx_php.c
@@ -321,9 +321,11 @@ void spx_php_print_stack(void)
 
                 fprintf(
                     stderr,
-                    " - depth = %3d, execute_data = %p",
+                    " - depth = %3d, execute_data = %p, internal = %s",
                     current_depth,
-                    execute_data
+                    execute_data,
+                    execute_data->func && execute_data->func->type == ZEND_INTERNAL_FUNCTION ?
+                        "true" : "false"
                 );
 
                 if (i == 0) {
@@ -376,6 +378,30 @@ int spx_php_previous_function(const spx_php_function_t * current, spx_php_functi
     }
 
     spx_php_function_at(current->depth - 1, previous);
+
+    return 1;
+}
+
+int spx_php_previous_userland_function(const spx_php_function_t * current, spx_php_function_t * previous)
+{
+    if (current->depth == 1) {
+        return 0;
+    }
+
+    size_t prev_depth = current->depth - 1;
+
+    for (;;) {
+        spx_php_function_at(prev_depth, previous);
+        if (! spx_php_is_internal_function(previous)) {
+            break;
+        }
+
+        if (prev_depth == 0) {
+            return 0;
+        }
+
+        prev_depth--;
+    }
 
     return 1;
 }

--- a/src/spx_php.h
+++ b/src/spx_php.h
@@ -43,6 +43,7 @@ void spx_php_print_stack(void);
 size_t spx_php_current_depth(void);
 void spx_php_current_function(spx_php_function_t * function);
 int spx_php_previous_function(const spx_php_function_t * current, spx_php_function_t * previous);
+int spx_php_previous_userland_function(const spx_php_function_t * current, spx_php_function_t * previous);
 void spx_php_function_at(size_t depth, spx_php_function_t * function);
 uint8_t spx_php_is_internal_function(const spx_php_function_t * function);
 size_t spx_php_function_call_site_line(const spx_php_function_t * function);

--- a/tests/spx_auto_start_008.phpt
+++ b/tests/spx_auto_start_008.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Auto start disabled, explicit start with internal function as caller
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_METRICS=zo
+SPX_REPORT=trace
+SPX_TRACE_FILE=/dev/stdout
+END;
+--FILE--
+<?php
+function foo() {
+    bar();
+}
+
+function bar() {
+    time();
+}
+
+array_map(
+    function() {
+        spx_profiler_start();
+        foo();
+        spx_profiler_stop();
+    },
+    [null]
+);
+
+?>
+--EXPECT--
+ZE object count                |
+ Cum.     | Inc.     | Exc.     | Depth    | Line     | Function
+----------+----------+----------+----------+----------+----------
+        0 |        0 |        0 |        1 |        0 | +/var/www/php-spx/tests/spx_auto_start_008.php
+        0 |        0 |        0 |        2 |       10 |  +{closure:/var/www/php-spx/tests/spx_auto_start_008.php:11}
+        0 |        0 |        0 |        3 |       13 |   +foo
+        0 |        0 |        0 |        4 |        3 |    +bar
+        0 |        0 |        0 |        4 |        0 |    -bar
+        0 |        0 |        0 |        3 |        0 |   -foo
+        0 |        0 |        0 |        2 |        0 |  -{closure:/var/www/php-spx/tests/spx_auto_start_008.php:11}
+        0 |        0 |        0 |        1 |        0 | -/var/www/php-spx/tests/spx_auto_start_008.php
+
+SPX trace file: /dev/stdout


### PR DESCRIPTION
Fixes a stack tracking issue when internal functions (calling userland callbacks) are present in the current stack but not instrumented by SPX. This partially addresses issue #316.