### PR TITLE
Add SPX_DROP_PROFILES_UNDER_MS to discard fast profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Added `SPX_DROP_PROFILES_UNDER_MS` parameter (with `spx.http_profiling_drop_profiles_under_ms` INI counterpart for HTTP requests) to discard profiles whose total wall time is below a configurable millisecond threshold. Default `0` keeps existing behavior. Useful for bounding disk usage when HTTP profiling is enabled broadly.
+
 ## [v0.4.22](https://github.com/NoiseByNorthwest/php-spx/compare/v0.4.21...v0.4.22)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ while ($task = get_next_ready_task()) {
 | _spx.http_profiling_sampling_period_ | _NULL_ | _PHP_INI_SYSTEM_ | The INI level counterpart of the `SPX_SAMPLING_PERIOD` parameter, for HTTP requests only. See [here for more details](#available-parameters). |
 | _spx.http_profiling_depth_ | _NULL_ | _PHP_INI_SYSTEM_ | The INI level counterpart of the `SPX_DEPTH` parameter, for HTTP requests only. See [here for more details](#available-parameters). |
 | _spx.http_profiling_metrics_ | _NULL_ | _PHP_INI_SYSTEM_ | The INI level counterpart of the `SPX_METRICS` parameter, for HTTP requests only. See [here for more details](#available-parameters). |
+| _spx.http_profiling_drop_profiles_under_ms_ | _NULL_ | _PHP_INI_SYSTEM_ | The INI level counterpart of the `SPX_DROP_PROFILES_UNDER_MS` parameter, for HTTP requests only. See [here for more details](#available-parameters). |
 
 _\*: `*` (match all) and subnet masks (e.g. `192.168.1.0/24`) are supported._
 
@@ -359,6 +360,7 @@ Here is the list below:
 | _SPX_FP_COLOR_ | `1` | Whether to enable flat profile color mode. |
 | _SPX_TRACE_SAFE_ | `0` | The trace file is by default written in a way to enforce accuracy, but in case of process crash (e.g. segfault) some logs could be lost. If you want to enforce durability (e.g. to find the last event before a crash) you just have to set this parameter to 1. |
 | _SPX_TRACE_FILE_ |  | Custom trace file name. If not specified it will be generated in `/tmp` and displayed on STDERR at the end of the script. |
+| _SPX_DROP_PROFILES_UNDER_MS_ | `0` | If greater than `0`, profiles whose total wall time (in milliseconds) is below this value are discarded — neither the profile data file nor the metadata file is saved. Useful to bound disk usage when HTTP profiling is broadly enabled: only profiles slow enough to be worth analyzing are kept. The default `0` means the feature is disabled and every profile is saved. |
 
 #### Setting parameters
 

--- a/src/php_spx.c
+++ b/src/php_spx.c
@@ -94,6 +94,7 @@ ZEND_BEGIN_MODULE_GLOBALS(spx)
     const char * http_profiling_sampling_period;
     const char * http_profiling_depth;
     const char * http_profiling_metrics;
+    const char * http_profiling_drop_profiles_under_ms;
 ZEND_END_MODULE_GLOBALS(spx)
 
 ZEND_DECLARE_MODULE_GLOBALS(spx)
@@ -160,6 +161,10 @@ PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY(
         "spx.http_profiling_metrics", NULL, PHP_INI_SYSTEM,
         OnUpdateString, http_profiling_metrics, zend_spx_globals, spx_globals
+    )
+    STD_PHP_INI_ENTRY(
+        "spx.http_profiling_drop_profiles_under_ms", NULL, PHP_INI_SYSTEM,
+        OnUpdateString, http_profiling_drop_profiles_under_ms, zend_spx_globals, spx_globals
     )
 PHP_INI_END()
 

--- a/src/php_spx.c
+++ b/src/php_spx.c
@@ -652,7 +652,10 @@ static void profiling_handler_start(void)
     switch (context.config.report) {
         default:
         case SPX_CONFIG_REPORT_FULL:
-            context.profiling_handler.reporter = spx_reporter_full_create(SPX_G(data_dir));
+            context.profiling_handler.reporter = spx_reporter_full_create(
+                SPX_G(data_dir),
+                context.config.drop_profiles_under_ms
+            );
             if (context.profiling_handler.reporter) {
                 snprintf(
                     context.profiling_handler.full_report_key,

--- a/src/spx_config.c
+++ b/src/spx_config.c
@@ -50,6 +50,7 @@ typedef struct {
 
     const char * trace_file;
     const char * trace_safe_str;
+    const char * drop_profiles_under_ms_str;
 } source_data_t;
 
 typedef const char * (*source_handler_t) (const char * parameter);
@@ -149,6 +150,7 @@ static void init_config(spx_config_t * config, int cli)
 
     config->trace_file = NULL;
     config->trace_safe = 0;
+    config->drop_profiles_under_ms = 0;
 }
 
 static void fix_config(spx_config_t * config, int cli)
@@ -190,6 +192,7 @@ static void source_data_get(source_data_t * source_data, source_handler_t handle
     source_data->fp_color_str         = handler("SPX_FP_COLOR");
     source_data->trace_file           = handler("SPX_TRACE_FILE");
     source_data->trace_safe_str       = handler("SPX_TRACE_SAFE");
+    source_data->drop_profiles_under_ms_str = handler("SPX_DROP_PROFILES_UNDER_MS");
 }
 
 static void source_data_to_config(const source_data_t * source_data, spx_config_t * config)
@@ -278,6 +281,11 @@ static void source_data_to_config(const source_data_t * source_data, spx_config_
 
     if (source_data->trace_safe_str) {
         config->trace_safe = *source_data->trace_safe_str == '1' ? 1 : 0;
+    }
+
+    if (source_data->drop_profiles_under_ms_str) {
+        int v = atoi(source_data->drop_profiles_under_ms_str);
+        config->drop_profiles_under_ms = v < 0 ? 0 : (size_t) v;
     }
 }
 

--- a/src/spx_config.h
+++ b/src/spx_config.h
@@ -52,6 +52,7 @@ typedef struct {
 
     const char * trace_file;
     int trace_safe;
+    size_t drop_profiles_under_ms;
 } spx_config_t;
 
 typedef enum {

--- a/src/spx_reporter_full.c
+++ b/src/spx_reporter_full.c
@@ -347,12 +347,16 @@ static void finalize(full_reporter_t * reporter, const spx_profiler_event_t * ev
         reporter->metadata->enabled_metrics[i] = event->enabled_metrics[i];
     });
 
-    if (reporter->drop_under_ms > 0
-        && reporter->metadata->wall_time_ms < reporter->drop_under_ms) {
-        spx_output_stream_close(reporter->output);
-        reporter->output = NULL;
-        unlink(reporter->profile_file_name);
-        return;
+    if (reporter->drop_under_ms > 0) {
+        const size_t wall_time_us = reporter->metadata->wall_time_ms;
+        const size_t threshold_us = reporter->drop_under_ms * 1000;
+
+        if (wall_time_us < threshold_us) {
+            spx_output_stream_close(reporter->output);
+            reporter->output = NULL;
+            unlink(reporter->profile_file_name);
+            return;
+        }
     }
 
     metadata_save(reporter->metadata, reporter->metadata_file_name);

--- a/src/spx_reporter_full.c
+++ b/src/spx_reporter_full.c
@@ -347,6 +347,14 @@ static void finalize(full_reporter_t * reporter, const spx_profiler_event_t * ev
         reporter->metadata->enabled_metrics[i] = event->enabled_metrics[i];
     });
 
+    if (reporter->drop_under_ms > 0
+        && reporter->metadata->wall_time_ms < reporter->drop_under_ms) {
+        spx_output_stream_close(reporter->output);
+        reporter->output = NULL;
+        unlink(reporter->profile_file_name);
+        return;
+    }
+
     metadata_save(reporter->metadata, reporter->metadata_file_name);
 }
 

--- a/src/spx_reporter_full.c
+++ b/src/spx_reporter_full.c
@@ -75,6 +75,9 @@ typedef struct {
     buffer_entry_t buffer[BUFFER_CAPACITY];
 
     spx_str_builder_t * str_builder;
+
+    size_t drop_under_ms;
+    char profile_file_name[PATH_MAX];
 } full_reporter_t;
 
 static spx_profiler_reporter_cost_t full_notify(
@@ -154,7 +157,7 @@ char * spx_reporter_full_build_file_name(
     );
 }
 
-spx_profiler_reporter_t * spx_reporter_full_create(const char * data_dir)
+spx_profiler_reporter_t * spx_reporter_full_create(const char * data_dir, size_t drop_under_ms)
 {
     full_reporter_t * reporter = malloc(sizeof(*reporter));
     if (!reporter) {
@@ -167,16 +170,16 @@ spx_profiler_reporter_t * spx_reporter_full_create(const char * data_dir)
     reporter->metadata = NULL;
     reporter->output = NULL;
     reporter->str_builder = NULL;
+    reporter->drop_under_ms = drop_under_ms;
 
     reporter->metadata = metadata_create();
     if (!reporter->metadata) {
         goto error;
     }
 
-    char file_name[PATH_MAX];
     snprintf(
-        file_name,
-        sizeof(file_name),
+        reporter->profile_file_name,
+        sizeof(reporter->profile_file_name),
         "%s/%s.txt.gz",
         data_dir,
         reporter->metadata->key
@@ -191,7 +194,7 @@ spx_profiler_reporter_t * spx_reporter_full_create(const char * data_dir)
     );
 
     (void) mkdir(data_dir, 0777);
-    reporter->output = spx_output_stream_open(file_name, 1);
+    reporter->output = spx_output_stream_open(reporter->profile_file_name, 1);
     if (!reporter->output) {
         goto error;
     }

--- a/src/spx_reporter_full.c
+++ b/src/spx_reporter_full.c
@@ -354,7 +354,7 @@ static void finalize(full_reporter_t * reporter, const spx_profiler_event_t * ev
         if (wall_time_us < threshold_us) {
             spx_output_stream_close(reporter->output);
             reporter->output = NULL;
-            unlink(reporter->profile_file_name);
+            (void) unlink(reporter->profile_file_name);
             return;
         }
     }

--- a/src/spx_reporter_full.h
+++ b/src/spx_reporter_full.h
@@ -40,7 +40,7 @@ char * spx_reporter_full_build_file_name(
     size_t size
 );
 
-spx_profiler_reporter_t * spx_reporter_full_create(const char * data_dir);
+spx_profiler_reporter_t * spx_reporter_full_create(const char * data_dir, size_t drop_under_ms);
 
 void spx_reporter_full_set_custom_metadata_str(
     const spx_profiler_reporter_t * base_reporter,

--- a/tests/spx_drop_profiles_under_ms_disabled.phpt
+++ b/tests/spx_drop_profiles_under_ms_disabled.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Drop profiles under ms threshold: 0/unset saves all profiles
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_REPORT=full
+END;
+--FILE--
+<?php
+function foo() {
+}
+
+spx_profiler_start();
+foo();
+$key = spx_profiler_stop();
+
+$json = '/tmp/spx/' . $key . '.json';
+$data = '/tmp/spx/' . $key . '.txt.gz';
+
+echo "json_exists=", file_exists($json) ? 'yes' : 'no', "\n";
+echo "data_exists=", file_exists($data) ? 'yes' : 'no', "\n";
+
+@unlink($json);
+@unlink($data);
+?>
+--EXPECT--
+json_exists=yes
+data_exists=yes

--- a/tests/spx_drop_profiles_under_ms_drop.phpt
+++ b/tests/spx_drop_profiles_under_ms_drop.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Drop profiles under ms threshold: profile is dropped
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_REPORT=full
+SPX_DROP_PROFILES_UNDER_MS=10000
+END;
+--FILE--
+<?php
+function foo() {
+}
+
+spx_profiler_start();
+foo();
+$key = spx_profiler_stop();
+
+$json = '/tmp/spx/' . $key . '.json';
+$data = '/tmp/spx/' . $key . '.txt.gz';
+
+echo "json_exists=", file_exists($json) ? 'yes' : 'no', "\n";
+echo "data_exists=", file_exists($data) ? 'yes' : 'no', "\n";
+
+@unlink($json);
+@unlink($data);
+?>
+--EXPECT--
+json_exists=no
+data_exists=no

--- a/tests/spx_drop_profiles_under_ms_keep.phpt
+++ b/tests/spx_drop_profiles_under_ms_keep.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Drop profiles under ms threshold: profile above threshold is kept
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_REPORT=full
+SPX_DROP_PROFILES_UNDER_MS=1
+END;
+--FILE--
+<?php
+function foo() {
+    usleep(50000); // 50ms — well above the 1ms threshold
+}
+
+spx_profiler_start();
+foo();
+$key = spx_profiler_stop();
+
+$json = '/tmp/spx/' . $key . '.json';
+$data = '/tmp/spx/' . $key . '.txt.gz';
+
+echo "json_exists=", file_exists($json) ? 'yes' : 'no', "\n";
+echo "data_exists=", file_exists($data) ? 'yes' : 'no', "\n";
+
+@unlink($json);
+@unlink($data);
+?>
+--EXPECT--
+json_exists=yes
+data_exists=yes

--- a/tests/spx_drop_profiles_under_ms_unit.phpt
+++ b/tests/spx_drop_profiles_under_ms_unit.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Drop profiles under ms threshold: threshold is interpreted in milliseconds (regression for unit-mismatch bug)
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_AUTO_START=0
+SPX_REPORT=full
+SPX_DROP_PROFILES_UNDER_MS=2
+END;
+--FILE--
+<?php
+function foo() {
+    usleep(1000); // 1ms — below the 2ms threshold; profile must be dropped
+}
+
+spx_profiler_start();
+foo();
+$key = spx_profiler_stop();
+
+$json = '/tmp/spx/' . $key . '.json';
+$data = '/tmp/spx/' . $key . '.txt.gz';
+
+echo "json_exists=", file_exists($json) ? 'yes' : 'no', "\n";
+echo "data_exists=", file_exists($data) ? 'yes' : 'no', "\n";
+
+@unlink($json);
+@unlink($data);
+?>
+--EXPECT--
+json_exists=no
+data_exists=no


### PR DESCRIPTION
 ## What

  New SPX parameter `SPX_DROP_PROFILES_UNDER_MS` (and `spx.http_profiling_drop_profiles_under_ms` for INI)

  ## Why

  If you turn on HTTP profiling for everything, your data dir fills up fast with profiles for fast 50ms requests you'll never look at. Set `spx.http_profiling_drop_profiles_under_ms = 1000` and you only keep the ones longer than 1 second, these are the slow ones actually worth opening.

  ## How to use it

  ```ini
  ; php.ini — keep only profiles >= 1s
  spx.http_profiling_drop_profiles_under_ms = 1000

  # CLI works too
  SPX_DROP_PROFILES_UNDER_MS=500 php script.php

  Default is 0 = disabled