### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add web UI ([#14](https://github.com/NoiseByNorthwest/php-spx/pull/14))
 - Add cookie based settings ([#3](https://github.com/NoiseByNorthwest/php-spx/issues/3))
 - Improve Linux timer precision (1us -> 1ns)
-- Improve accuracy by evaluating and then substracting probes overhead
+- Improve accuracy by evaluating and then subtracting probes overhead
 
 ## Changed
 - Remove Google Trace Event report type ([#10](https://github.com/NoiseByNorthwest/php-spx/issues/10))

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You may also want to override [default SPX configuration](#configuration) to be 
 ### ZTS PHP (multi-thread)
 
 ZTS PHP is supported, with these extra limitations:
-- a little overhead (theorically unnoticeable in most cases) is added when SPX is loaded, even if it is not enabled.
+- a little overhead (theoretically unnoticeable in most cases) is added when SPX is loaded, even if it is not enabled.
 - Ctrl-C a CLI script will not make the possible profiling session to be properly finished.
 - segfaults are more likely than for NTS PHP. In this regard, avoid more than ever mixing SPX with other instrumenting extensions (debuggers, profilers...).
 
@@ -226,7 +226,7 @@ This is especially true for the long-living process use case which otherwise wou
 
 To do that SPX exposes the `spx_profiler_full_report_set_custom_metadata_str(string $customMetadataStr): void` function.
 
-As you may have notificed, this function accepts a string as custom metadata, for the sake of flexibility and simplicity on SPX side. It is up to you to encode any structured data to a string, for instance using JSON format.
+As you may have noticed, this function accepts a string as custom metadata, for the sake of flexibility and simplicity on SPX side. It is up to you to encode any structured data to a string, for instance using JSON format.
 
 The metadata string is limited to 4KB, which is large enough for most use cases. If you pass a string exceeding this limit it will be discarded and a notice log will be emitted.
 

--- a/src/php_spx.c
+++ b/src/php_spx.c
@@ -783,9 +783,9 @@ static void profiling_handler_ex_hook_before(void)
         name in the context.profiling_handler.stack array even for
         non-profiled functions.
         But I've no other choice since I currently don't know how to safely
-        & accuratly resolve the current stack (accordingly to SPX_BUILTINS)
+        & accurately resolve the current stack (accordingly to SPX_BUILTINS)
         via the Zend Engine.
-        The induced overhead will, however, not be noticable in most cases.
+        The induced overhead will, however, not be noticeable in most cases.
     */
 
     if (context.profiling_handler.depth == STACK_CAPACITY) {

--- a/src/spx_profiler_sampler.c
+++ b/src/spx_profiler_sampler.c
@@ -173,7 +173,7 @@ static void sampling_profiler_handle_sample(sampling_profiler_t * profiler, int 
 
         /*
             We cannot check the function & class name as the previous call stack related pointers
-            may be invalid. This is however not a big issue, aliased functions will only slighlty
+            may be invalid. This is however not a big issue, aliased functions will only slightly
             reduce the correctness of the report.
          */
 

--- a/src/spx_utils.c
+++ b/src/spx_utils.c
@@ -202,7 +202,7 @@ char * spx_utils_json_escape(char * dst, const char * src, size_t limit)
 limit_reached:
     spx_utils_die("The provided buffer is too small to contain the escaped JSON string");
 
-    /* unreacheable */
+    /* unreachable */
     return NULL;
 }
 


### PR DESCRIPTION
Correct new misspellings in 2026.

Using https://github.com/crate-ci/typos