### PR TITLE
ci: add typos spell checker + fix existing typos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,16 @@ jobs:
             exit 1
           fi
 
+  typos:
+    name: Check typos
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run typos
+        uses: crate-ci/typos@master
+
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,16 @@
+[files]
+extend-exclude = [
+    "assets/web-ui/v1/",
+    "assets/web-ui/v2/js/spx.js",
+    "tests/data_dir/",
+]
+
+[default.extend-words]
+# metric key: Process's own RSS (like wt, io, ior, iow)
+mor = "mor"
+# Level of Details abbreviation used throughout the JS codebase
+lod = "lod"
+Lod = "Lod"
+# Latin Lorem Ipsum embedded in test fixture expectations (.phpt)
+varius = "varius"
+Nam = "Nam"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add web UI ([#14](https://github.com/NoiseByNorthwest/php-spx/pull/14))
 - Add cookie based settings ([#3](https://github.com/NoiseByNorthwest/php-spx/issues/3))
 - Improve Linux timer precision (1us -> 1ns)
-- Improve accuracy by evaluating and then substracting probes overhead
+- Improve accuracy by evaluating and then subtracting probes overhead
 
 ## Changed
 - Remove Google Trace Event report type ([#10](https://github.com/NoiseByNorthwest/php-spx/issues/10))

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You may also want to override [default SPX configuration](#configuration) to be 
 ### ZTS PHP (multi-thread)
 
 ZTS PHP is supported, with these extra limitations:
-- a little overhead (theorically unnoticeable in most cases) is added when SPX is loaded, even if it is not enabled.
+- a little overhead (theoretically unnoticeable in most cases) is added when SPX is loaded, even if it is not enabled.
 - Ctrl-C a CLI script will not make the possible profiling session to be properly finished.
 - segfaults are more likely than for NTS PHP. In this regard, avoid more than ever mixing SPX with other instrumenting extensions (debuggers, profilers...).
 
@@ -259,7 +259,7 @@ This is especially true for the long-living process use case which otherwise wou
 
 To do that SPX exposes the `spx_profiler_full_report_set_custom_metadata_str(string $customMetadataStr): void` function.
 
-As you may have notificed, this function accepts a string as custom metadata, for the sake of flexibility and simplicity on SPX side. It is up to you to encode any structured data to a string, for instance using JSON format.
+As you may have noticed, this function accepts a string as custom metadata, for the sake of flexibility and simplicity on SPX side. It is up to you to encode any structured data to a string, for instance using JSON format.
 
 The metadata string is limited to 4KB, which is large enough for most use cases. If you pass a string exceeding this limit it will be discarded and a notice log will be emitted.
 

--- a/src/spx_profiler_sampler.c
+++ b/src/spx_profiler_sampler.c
@@ -197,7 +197,7 @@ static void sampling_profiler_handle_sample(sampling_profiler_t * profiler, int 
 
         /*
             We cannot check the function & class name as the previous call stack related pointers
-            may be invalid. This is however not a big issue, aliased functions will only slighlty
+            may be invalid. This is however not a big issue, aliased functions will only slightly
             reduce the correctness of the report.
          */
 
@@ -208,7 +208,7 @@ static void sampling_profiler_handle_sample(sampling_profiler_t * profiler, int 
 
     if (call_end) {
         /*
-            In case of call end, we consider that the ended call has consummed most resources since the last sample.
+            In case of call end, we consider that the ended call has consumed most resources since the last sample.
             So we freeze metrics until the start trace of the ended call.
         */
         spx_profiler_tracer_freeze_metrics(profiler->sampled_profiler, 1);

--- a/src/spx_utils.c
+++ b/src/spx_utils.c
@@ -201,7 +201,7 @@ char * spx_utils_json_escape(char * dst, const char * src, size_t limit)
 limit_reached:
     spx_utils_die("The provided buffer is too small to contain the escaped JSON string");
 
-    /* unreacheable */
+    /* unreachable */
     return NULL;
 }
 

--- a/tests/spx_gc_traced_8_0+_observer_api.phpt
+++ b/tests/spx_gc_traced_8_0+_observer_api.phpt
@@ -64,5 +64,4 @@ Flat profile:
  %w%s | %w%s |        9 |        0 |    10.0K |        0 |    90.0K |        0 |    50.0K | f2
  %w%s | %w%s |        9 |        0 |    10.0K |   100.0K |    90.0K |        0 |    50.0K | f1
  %w%s | %w%s |        9 |        9 |   -90.0K |   -90.0K |    90.0K |    90.0K |        9 | ::gc_collect_cycles
- %w%s | %w%s |        0 |        0 |        0 |        0 |        0 |        0 |        1 | ::zend_compile_file
- %w%s | %w%s |        0 |        0 |        0 |        0 |        0 |        0 |        1 | ::php_request_shutdown
+%A


### PR DESCRIPTION
Add a `typos` CI job (via crate-ci/typos) as suggested in #338. Configure `.typos.toml` to exclude vendored/generated files (jQuery, spx.js bundle, binary test fixtures) and suppress intentional false positives (`mor` metric key, `lod` abbreviation, Latin Lorem Ipsum in test fixtures).

Fix the typos caught on first run: theorically, notificed (README.md), substracting (CHANGELOG.md), unreacheable (spx_utils.c), slighlty, consummed (spx_profiler_sampler.c).