### PR TITLE
fix: correct function-table identity for closures, eval and inherited methods

### DIFF
--- a/src/spx_php.c
+++ b/src/spx_php.c
@@ -48,6 +48,19 @@
 #include "spx_str_builder.h"
 #include "spx_utils.h"
 
+
+/*
+    SPX_PHP_FUNCTION_IDENTITY_NEEDS_LOCATION drives whether file_name/line is added to the
+    function identity (func_name, class_name). Required only up to PHP 8.3: there every
+    closure is named "{closure}", so two closures in the same scope are told apart only by
+    their definition site. Since 8.4 the name embeds that site.
+*/
+#if ZEND_MODULE_API_NO < 20240924 /* PHP < 8.4 */
+#   define SPX_PHP_FUNCTION_IDENTITY_NEEDS_LOCATION 1
+#else
+#   define SPX_PHP_FUNCTION_IDENTITY_NEEDS_LOCATION 0
+#endif
+
 #define ZE_HASHTABLE_FOREACH(ht, entry, block)                  \
 do {                                                            \
     void * entry;                                               \
@@ -215,6 +228,7 @@ static void global_hook_zend_error_cb(
 #endif
 );
 
+static uint64_t resolve_function_hash_code(const spx_php_function_t * function);
 static void push_frame(uint8_t special_function, void * data);
 static void update_userland_stats(void);
 
@@ -422,7 +436,7 @@ void spx_php_function_at(size_t depth, spx_php_function_t * function)
     if (context.stack[function->depth - 1].special_function) {
         function->class_name = "";
         function->func_name = context.stack[function->depth - 1].data.function_name;
-        function->hash_code = zend_inline_hash_func(function->func_name, strlen(function->func_name));
+        function->hash_code = resolve_function_hash_code(function);
     } else {
         execute_data_function(
             context.stack[function->depth - 1].data.execute_data,
@@ -479,6 +493,32 @@ size_t spx_php_function_call_site_line(const spx_php_function_t * function)
     }
 
     return prev_execute_data->opline->lineno;
+}
+
+int spx_php_function_cmp(const spx_php_function_t * a, const spx_php_function_t * b)
+{
+    int n;
+
+    n = strcmp(a->func_name, b->func_name);
+    if (n != 0) {
+        return n;
+    }
+
+    n = strcmp(a->class_name, b->class_name);
+    if (n != 0) {
+        return n;
+    }
+
+#if SPX_PHP_FUNCTION_IDENTITY_NEEDS_LOCATION
+    n = strcmp(a->file_name, b->file_name);
+    if (n != 0) {
+        return n;
+    }
+
+    return (int) a->line - (int) b->line;
+#else
+    return 0;
+#endif
 }
 
 const char * spx_php_ini_get_string(const char * name)
@@ -1020,14 +1060,11 @@ static void execute_data_function(
     const zend_execute_data * execute_data,
     spx_php_function_t * function
 ) {
-    int closure = 0;
     const zend_function * func = NULL;
     const zend_class_entry * ce = NULL;
 
     if (execute_data && zend_is_executing()) {
         func = execute_data->func;
-
-        closure = func->common.fn_flags & ZEND_ACC_CLOSURE;
 
         if (func->type == ZEND_EVAL_CODE) {
             function->file_name = "eval()";
@@ -1109,20 +1146,24 @@ static void execute_data_function(
         }
     }
 
-    if (func && ! closure) {
-        /*
-            Hashing the (non-closure) function address is safe since it always point to the same
-            function table entry for the whole script's lifespan.
-        */
-        function->hash_code = zend_inline_hash_func((void *)&func, sizeof(void *));
-        if (ce && ce->ce_flags & ZEND_ACC_ANON_CLASS) {
-            function->hash_code ^= zend_inline_hash_func(function->class_name, strlen(function->class_name));
-        }
+    /*
+        A named user function or method has a single op_array for the whole script, so its address is
+        a stable unique key: hash it directly. The other cases map several addresses onto one function,
+        so fall back to the textual identity:
+          - eval() recompiles a fresh op_array on each call;
+          - an internal method is copied into each inheriting class;
+          - a closure is copied into every Closure instance of the same literal;
+          - an anonymous class may be recompiled.
+    */
+    if (
+        func
+        && func->type == ZEND_USER_FUNCTION
+        && !(func->common.fn_flags & ZEND_ACC_CLOSURE)
+        && !(ce && (ce->ce_flags & ZEND_ACC_ANON_CLASS))
+    ) {
+        function->hash_code = zend_inline_hash_func((void *) &func, sizeof(void *));
     } else {
-        function->hash_code =
-            zend_inline_hash_func(function->file_name, strlen(function->file_name))
-                ^ zend_inline_hash_func((void *) &function->line, sizeof(function->line))
-        ;
+        function->hash_code = resolve_function_hash_code(function);
     }
 }
 
@@ -1599,6 +1640,21 @@ static void global_hook_zend_error_cb(
         args
 #endif
     );
+}
+
+static uint64_t resolve_function_hash_code(const spx_php_function_t * function)
+{
+    return zend_inline_hash_func(function->func_name, strlen(function->func_name))
+        ^ zend_inline_hash_func(function->class_name, strlen(function->class_name))
+#if SPX_PHP_FUNCTION_IDENTITY_NEEDS_LOCATION
+        /*
+            Mixed in only to spread entries that share the same func_name/class_name
+            (every "{closure}" before 8.4) across the buckets instead of piling into one.
+        */
+        ^ zend_inline_hash_func(function->file_name, strlen(function->file_name))
+        ^ zend_inline_hash_func((void *) &function->line, sizeof(function->line))
+#endif
+    ;
 }
 
 static void push_frame(uint8_t special_function, void * data)

--- a/src/spx_php.h
+++ b/src/spx_php.h
@@ -23,7 +23,6 @@
 
 #include "main/php.h"
 
-
 #define SPX_PHP_STACK_CAPACITY 16384
 
 typedef struct {
@@ -47,6 +46,7 @@ int spx_php_previous_userland_function(const spx_php_function_t * current, spx_p
 void spx_php_function_at(size_t depth, spx_php_function_t * function);
 uint8_t spx_php_is_internal_function(const spx_php_function_t * function);
 size_t spx_php_function_call_site_line(const spx_php_function_t * function);
+int spx_php_function_cmp(const spx_php_function_t * a, const spx_php_function_t * b);
 
 const char * spx_php_ini_get_string(const char * name);
 double spx_php_ini_get_double(const char * name);

--- a/src/spx_profiler_tracer.c
+++ b/src/spx_profiler_tracer.c
@@ -133,7 +133,7 @@ static spx_profiler_reporter_cost_t null_reporter_notify(
 static void calibrate(tracing_profiler_t * profiler, const spx_php_function_t * function);
 
 static uint64_t func_table_hmap_hash_key(const void * v);
-static int func_table_hmap_cmp_key(const void * va, const void * vb);
+static int func_table_hmap_cmp_key(const void * a, const void * b);
 
 static spx_profiler_func_table_entry_t * func_table_get_entry(
     tracing_profiler_t * profiler,
@@ -601,24 +601,9 @@ static uint64_t func_table_hmap_hash_key(const void * v)
     return ((const spx_php_function_t *) v)->hash_code;
 }
 
-static int func_table_hmap_cmp_key(const void * va, const void * vb)
+static int func_table_hmap_cmp_key(const void * a, const void * b)
 {
-    const spx_php_function_t * a = va;
-    const spx_php_function_t * b = vb;
-
-    int n;
-
-    n = strcmp(a->func_name, b->func_name);
-    if (n != 0) {
-        return n;
-    }
-
-    n = strcmp(a->class_name, b->class_name);
-    if (n != 0) {
-        return n;
-    }
-
-    return 0;
+    return spx_php_function_cmp(a, b);
 }
 
 static spx_profiler_func_table_entry_t * func_table_get_entry(

--- a/tests/spx_bug_function_identity.phpt
+++ b/tests/spx_bug_function_identity.phpt
@@ -1,0 +1,68 @@
+--TEST--
+function-table identity: no duplication (one function per entry) and no aliasing (distinct functions kept apart)
+--INI--
+spx.use_observer_api=0
+--ENV--
+return <<<END
+SPX_ENABLED=1
+SPX_BUILTINS=1
+SPX_AUTO_START=1
+SPX_REPORT=fp
+SPX_METRICS=zuo
+SPX_FP_FOCUS=zuo
+END;
+--FILE--
+<?php
+/*
+ *  Regression guard for the function-table identity, which must avoid two opposite
+ *  defects:
+ *    - duplication: one logical function split across several entries;
+ *    - aliasing: several distinct functions merged onto one entry.
+ *
+ *  Each scenario below covers one of these, described in the comment above it.
+ *
+ *  The output also lists three internal functions ("::zend_compile_file",
+ *  "::zend_compile_string", "::php_request_shutdown"): like ArrayObject::count, they
+ *  only show up because SPX_BUILTINS=1 which is required for the case (2).
+ */
+
+class A extends ArrayObject {}
+class B extends ArrayObject {}
+
+// (1) recompilation (anti-duplication): each eval() recompiles a fresh function, but
+// its identity is keyed on the call site. The three eval()s share one call site, so
+// they aggregate into one entry.
+for ($i = 0; $i < 3; $i++) {
+    eval('return 1;');
+}
+
+// (2) inheritance (anti-duplication): ArrayObject::count is an internal method
+// inherited by A and B, it is copied into each child while keeping its defining
+// scope, so reached through A and B it must aggregate into one entry. Being internal,
+// it is only profiled with SPX_BUILTINS=1 (set in --ENV-- above).
+(new A())->count();
+(new B())->count();
+
+// (3) closures (anti-aliasing): before PHP 8.4 every closure is named "{closure}",
+// so $c1 and $c2 differ only by their definition site. They must stay on one entry each.
+$c1 = function () { return 1; };
+$c2 = function () { return 2; };
+$c1();
+$c2();
+?>
+--EXPECTF--
+%a
+Flat profile:
+
+%s
+%s
+%s
+ %s | %s | %s | ::zend_compile_file
+ %s | %s | %s | ::zend_compile_string
+ %s | %s | %s | %s/spx_bug_function_identity.php
+ %s | %s | %s | %s/spx_bug_function_identity.php(%d) : eval()'d code
+ %s | %s | %s | ArrayObject::__construct
+ %s | %s | %s | ArrayObject::count
+ %s | %s | %s | {closure:%s/spx_bug_function_identity.php:%d}
+ %s | %s | %s | {closure:%s/spx_bug_function_identity.php:%d}
+ %s | %s | %s | ::php_request_shutdown


### PR DESCRIPTION
The function hash/identity could both duplicate a single logical function across several entries and alias distinct functions onto one entry.

Hashing the op_array address is only valid for a named user function/method, whose address is stable for the whole script. The other cases map several addresses onto one logical function (eval recompiles, internal methods are copied into each child, closures into each Closure instance, anonymous classes may be recompiled), so they now fall back to a textual identity (func_name + class_name, plus file_name/line on PHP < 8.4 where every closure is named "{closure}").