### PR TITLE
Compile PHP 8.5 on Debian

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
           - { name: debian, ts: 'nts', compiler: 'gcc',   os: ubuntu-24.04 }
           # macOS
           - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-15 }
-        exclude:
     env:
       DOCKER_BUILD_RECORD_UPLOAD: false   # disable docker buildx record upload as build artifact
       DOCKER_BUILD_SUMMARY: false         # disable docker buildx summary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,6 @@ jobs:
           # macOS
           - { name: mac,    ts: 'nts', compiler: 'clang', os: macos-15 }
         exclude:
-          # PHP 8.5 is temporarily excluded for Debian builds.
-          # Once it is available in the official packages from Ondřej Surý (packages.sury.org),
-          # this exclusion can be removed.
-          - { name: debian, php: '8.5' }
     env:
       DOCKER_BUILD_RECORD_UPLOAD: false   # disable docker buildx record upload as build artifact
       DOCKER_BUILD_SUMMARY: false         # disable docker buildx summary


### PR DESCRIPTION
Removed temporary exclusion of PHP 8.5 for Debian builds.

Please see https://packages.sury.org/php/pool/main/p/php8.5/